### PR TITLE
App shows an update for "FaxBot" when it is already up-to-date

### DIFF
--- a/Latest/Model/App Bundles/SparkleAppBundle.swift
+++ b/Latest/Model/App Bundles/SparkleAppBundle.swift
@@ -55,17 +55,8 @@ class SparkleAppBundle: AppBundle, XMLParserDelegate {
         // Lets find the version number
         switch elementName {
         case "enclosure":
-            let versionNumber = attributeDict["sparkle:shortVersionString"]
-            let buildNumber = attributeDict["sparkle:version"]
-            
-            if let vn = versionNumber, let bn = buildNumber {
-                info.version.versionNumber = vn
-                info.version.buildNumber = bn
-            } else if let vn = versionNumber {
-                info.version.versionNumber = vn
-            } else if let bn = buildNumber {
-                info.version.buildNumber = bn
-            }
+            info.version.versionNumber = attributeDict["sparkle:shortVersionString"]
+            info.version.buildNumber = attributeDict["sparkle:version"]
         case "pubDate":
             self.currentlyParsing = .pubDate
         case "sparkle:releaseNotesLink":

--- a/Latest/Model/App Bundles/SparkleAppBundle.swift
+++ b/Latest/Model/App Bundles/SparkleAppBundle.swift
@@ -64,7 +64,7 @@ class SparkleAppBundle: AppBundle, XMLParserDelegate {
             } else if let vn = versionNumber {
                 info.version.versionNumber = vn
             } else if let bn = buildNumber {
-                info.version.versionNumber = bn
+                info.version.buildNumber = bn
             }
         case "pubDate":
             self.currentlyParsing = .pubDate


### PR DESCRIPTION
There was a problem with the app "FaxBot". The user interface showed that an update was available when there really wasn't.

The sparkle feed for FaxBot only contains the build number in the "sparkle:version" attribute. It looks like this was actually used as the version number when it should be the build number:

<img width="869" alt="bildschirmfoto 2018-06-01 um 15 39 36" src="https://user-images.githubusercontent.com/1008289/40843845-9cebbaf6-65b2-11e8-8558-6727edcb57b7.png">

With the change in this pull request, the issue seems to be fixed.