### PR TITLE
Add toggle to show/hide in-app apps

### DIFF
--- a/Latest/Interface/Base.lproj/Main.storyboard
+++ b/Latest/Interface/Base.lproj/Main.storyboard
@@ -329,6 +329,12 @@
                                                 <action selector="toggleShowUnsupportedUpdates:" target="Ady-hI-5gd" id="URA-qk-ZAz"/>
                                             </connections>
                                         </menuItem>
+                                        <menuItem title="Show In-App Apps" keyEquivalent="i" id="JJd-a5-Jvj">
+                                            <modifierMask key="keyEquivalentModifierMask" control="YES" command="YES"/>
+                                            <connections>
+                                                <action selector="toggleShowInAppUpdates:" target="Ady-hI-5gd" id="TJi-ap-N1b"/>
+                                            </connections>
+                                        </menuItem>
                                         <menuItem isSeparatorItem="YES" id="2cf-83-Jly"/>
                                         <menuItem title="Check for Updates…" keyEquivalent="r" id="c4C-I9-Gd0">
                                             <connections>

--- a/Latest/Interface/Update Table View/Controller/UpdateTableViewController.swift
+++ b/Latest/Interface/Update Table View/Controller/UpdateTableViewController.swift
@@ -59,6 +59,17 @@ class UpdateTableViewController: NSViewController, NSMenuItemValidation, NSTable
 		}
 	}
     
+    /// Whether in-app apps should be visible
+    var showInAppUpdates: Bool {
+        set {
+            self.dataStore.showInAppUpdates = newValue
+        }
+        
+        get {
+            return self.dataStore.showInAppUpdates
+        }
+    }
+    
     /// The detail view controller that shows the release notes
     weak var releaseNotesViewController : ReleaseNotesViewController?
     

--- a/Latest/Interface/Window Controllers/MainWindowController.swift
+++ b/Latest/Interface/Window Controllers/MainWindowController.swift
@@ -21,6 +21,7 @@ class MainWindowController: NSWindowController, NSMenuItemValidation, NSMenuDele
     private let ShowInstalledUpdatesKey = "ShowInstalledUpdatesKey"
 	private let ShowIgnoredUpdatesKey = "ShowIgnoredUpdatesKey"
 	private let ShowUnsupportedUpdatesKey = "ShowUnsupportedUpdatesKey"
+    private let ShowInAppUpdatesKey = "ShowInAppUpdatesKey"
     
     /// The list view holding the apps
     lazy var listViewController : UpdateTableViewController = {
@@ -85,6 +86,7 @@ class MainWindowController: NSWindowController, NSMenuItemValidation, NSMenuDele
         self.updateShowInstalledUpdatesState(with: UserDefaults.standard.bool(forKey: ShowInstalledUpdatesKey))
         self.updateShowIgnoredUpdatesState(with: UserDefaults.standard.bool(forKey: ShowIgnoredUpdatesKey))
 		self.updateShowUnsupportedUpdatesState(with: UserDefaults.standard.bool(forKey: ShowUnsupportedUpdatesKey))
+        self.updateShowInAppUpdatesState(with: UserDefaults.standard.bool(forKey: ShowInAppUpdatesKey))
     }
 
     
@@ -115,6 +117,10 @@ class MainWindowController: NSWindowController, NSMenuItemValidation, NSMenuDele
 	@IBAction func toggleShowUnsupportedUpdates(_ sender: NSMenuItem?) {
 		self.updateShowUnsupportedUpdatesState(with: !UserDefaults.standard.bool(forKey: ShowUnsupportedUpdatesKey))
 	}
+    
+    @IBAction func toggleShowInAppUpdates(_ sender: NSMenuItem?) {
+        self.updateShowInAppUpdatesState(with: !UserDefaults.standard.bool(forKey: ShowInAppUpdatesKey))
+    }
 	
 	@IBAction func visitWebsite(_ sender: NSMenuItem?) {
 		NSWorkspace.shared.open(URL(string: "https://max.codes/latest")!)
@@ -156,6 +162,8 @@ class MainWindowController: NSWindowController, NSMenuItemValidation, NSMenuDele
                 menuItem.state = self.listViewController.showIgnoredUpdates ? .on : .off
 			case #selector(toggleShowUnsupportedUpdates(_:)):
 				menuItem.state = self.listViewController.showUnsupportedUpdates ? .on : .off
+            case #selector(toggleShowInAppUpdates(_:)):
+                menuItem.state = self.listViewController.showInAppUpdates ? .on : .off
             default:
                 ()
             }
@@ -213,6 +221,11 @@ class MainWindowController: NSWindowController, NSMenuItemValidation, NSMenuDele
 		self.listViewController.showUnsupportedUpdates = newState
 		UserDefaults.standard.set(newState, forKey: ShowUnsupportedUpdatesKey)
 	}
+    
+    private func updateShowInAppUpdatesState(with newState: Bool) {
+        self.listViewController.showInAppUpdates = newState
+        UserDefaults.standard.set(newState, forKey: ShowInAppUpdatesKey)
+    }
 	
     private func showReleaseNotes(_ show: Bool, animated: Bool) {
         guard let splitViewController = self.contentViewController as? NSSplitViewController else {

--- a/Latest/Model/AppDataStore.swift
+++ b/Latest/Model/AppDataStore.swift
@@ -79,6 +79,11 @@ class AppDataStore {
 		if !self.showUnsupportedUpdates {
 			visibleApps = visibleApps.filter({ type(of: $0).supported })
 		}
+        
+        // Filter in-app apps
+        if !self.showInAppUpdates {
+            visibleApps = visibleApps.filter({ !$0.url.path.contains(".app/") })
+        }
 		
 		// Apply filter query
 		if let filterQuery = self.filterQuery {
@@ -162,6 +167,13 @@ class AppDataStore {
 			self.scheduleFilterUpdate()
 		}
 	}
+    
+    /// Whether in-app apps should be visible
+    var showInAppUpdates = false {
+        didSet {
+            self.scheduleFilterUpdate()
+        }
+    }
 	
 	/// Returns the app at the given index, if any.
 	func app(at index: Int) -> AppBundle? {


### PR DESCRIPTION
Allows, for instance, to hide the apps in Xcode.app while showing the unsupported apps.