### PR TITLE
Fallback to local filesystem search if Spotlight does not list anything

### DIFF
--- a/Latest/Model/AppLibrary.swift
+++ b/Latest/Model/AppLibrary.swift
@@ -52,9 +52,8 @@ class AppLibrary {
 			// Look for applications in the /Applications folder manually
 			let fileManager = FileManager.default
 			var bundles = [App.Bundle]()
-			do {
-				for applicationPath in Self.applicationPaths {
-					let appPaths = try fileManager.contentsOfDirectory(atPath: applicationPath)
+			for applicationPath in Self.applicationPaths {
+				if let appPaths = try? fileManager.contentsOfDirectory(atPath: applicationPath) {
 					for appPath in appPaths {
 						let url = URL(fileURLWithPath: applicationPath + "/" + appPath)
 						if Self.excludedSubfolders.contains(where: { url.path.contains($0) }) {
@@ -64,8 +63,7 @@ class AppLibrary {
 							bundles.append(bundle)
 						}
 					}
-				}
-			} catch {
+				}				
 			}
 			self.bundles = bundles
 		} else {

--- a/Latest/Model/AppLibrary.swift
+++ b/Latest/Model/AppLibrary.swift
@@ -57,7 +57,7 @@ class AppLibrary {
 					let appPaths = try fileManager.contentsOfDirectory(atPath: applicationPath)
 					for appPath in appPaths {
 						let url = URL(fileURLWithPath: applicationPath + "/" + appPath)
-						if !Self.applicationPaths.contains(where: { url.path.hasPrefix($0) }) || Self.excludedSubfolders.contains(where: { url.path.contains($0) }) {
+						if Self.excludedSubfolders.contains(where: { url.path.contains($0) }) {
 							continue
 						}
 						if let bundle = self.bundle(forAppAt: url) {
@@ -77,7 +77,7 @@ class AppLibrary {
 				let url = URL(fileURLWithPath: path)
 				
 				// Only allow apps in the application folder and outside excluded subfolders
-				if !Self.applicationPaths.contains(where: { url.path.hasPrefix($0) }) || Self.excludedSubfolders.contains(where: { url.path.contains($0) }) {
+				if Self.excludedSubfolders.contains(where: { url.path.contains($0) }) {
 					return nil
 				}
 				

--- a/Latest/Model/AppLibrary.swift
+++ b/Latest/Model/AppLibrary.swift
@@ -55,7 +55,7 @@ class AppLibrary {
 			for applicationPath in Self.applicationPaths {
 				if let appPaths = try? fileManager.contentsOfDirectory(atPath: applicationPath) {
 					for appPath in appPaths {
-						let url = URL(fileURLWithPath: applicationPath + "/" + appPath)
+						let url = URL(fileURLWithPath: applicationPath).appendingPathComponent(appPath)
 						if Self.excludedSubfolders.contains(where: { url.path.contains($0) }) {
 							continue
 						}
@@ -63,7 +63,7 @@ class AppLibrary {
 							bundles.append(bundle)
 						}
 					}
-				}				
+				}
 			}
 			self.bundles = bundles
 		} else {


### PR DESCRIPTION
When Spotlight is disabled (globally or for the Applications folder), or isn't working correctly and doesn't return any applications, enumerate them directly from the filesystem instead. 
P.S. Thanks for the great app.