### PR TITLE
Open applications asynchronously in macOS 10.15 and later

### DIFF
--- a/Latest/Model/Bundle.swift
+++ b/Latest/Model/Bundle.swift
@@ -53,7 +53,14 @@ extension App {
 		
 		/// Opens the app and a given index
 		func open() {
-			NSWorkspace.shared.open(self.fileURL)
+			if #available(macOS 10.15, *) {
+				// Open application asynchronously
+				let configuration = NSWorkspace.OpenConfiguration()
+				NSWorkspace.shared.open(self.fileURL, configuration: configuration, completionHandler: nil)
+			} else {
+				// Open application synchronously
+				NSWorkspace.shared.open(self.fileURL)
+			}
 		}
 		
 		


### PR DESCRIPTION
> I don't know if this PR should be against `main` or `develop`, feel free to change that. Also sorry that I didn't open an issue first; but the proposed fix is very straight-forward.

Latest opens applications with the [synchronous method](https://developer.apple.com/documentation/appkit/nsworkspace/1533463-open), which makes it wait for the opening. This can be a long time for big apps (or if online connectivity is spotty), during which Latest remains unresponsive.

To fix that, we can use the [asynchronous method](https://developer.apple.com/documentation/appkit/nsworkspace/3172701-open), which doesn't make the thread (and the app) wait. It is only available in macOS 10.15+, so we wrap it in an `@available` check.

The same way that in the previous code we ignored the return value, we can ignore the `completionHandler` here too.