### PR TITLE
Add @unchecked Sendable attribute

### DIFF
--- a/Latest/Model/Update Checker Extensions/App Store/MacAppStoreCheckerOperation.swift
+++ b/Latest/Model/Update Checker Extensions/App Store/MacAppStoreCheckerOperation.swift
@@ -11,7 +11,7 @@ import Cocoa
 let MalformedURLError = NSError(domain: NSURLErrorDomain, code: NSURLErrorUnsupportedURL, userInfo: nil)
 
 /// The operation for checking for updates for a Mac App Store app.
-class MacAppStoreUpdateCheckerOperation: StatefulOperation, UpdateCheckerOperation {
+class MacAppStoreUpdateCheckerOperation: StatefulOperation, UpdateCheckerOperation, @unchecked Sendable {
 	
 	// MARK: - Update Check
 	

--- a/Latest/Model/Update Checker Extensions/Homebrew/HomebrewCheckerOperation.swift
+++ b/Latest/Model/Update Checker Extensions/Homebrew/HomebrewCheckerOperation.swift
@@ -9,7 +9,7 @@
 import Cocoa
 
 /// The operation for checking for updates via Homebrew.
-class HomebrewCheckerOperation: StatefulOperation, UpdateCheckerOperation {
+class HomebrewCheckerOperation: StatefulOperation, UpdateCheckerOperation, @unchecked Sendable {
 	
 	static var sourceType: App.Source {
 		return .unsupported

--- a/Latest/Model/Utilities/StatefulOperation.swift
+++ b/Latest/Model/Utilities/StatefulOperation.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 /// An convenience operation adding state to Operations.
-class StatefulOperation: Operation {
+class StatefulOperation: Operation, @unchecked Sendable {
 
     // MARK: State Management
     


### PR DESCRIPTION
- Applied `@unchecked Sendable` to `MacAppStoreUpdateCheckerOperation`, `HomebrewCheckerOperation`, and `StatefulOperation`.
- Restated inherited `@unchecked Sendable` conformance in `MacAppStoreUpdateCheckerOperation`, `HomebrewCheckerOperation`, and `StatefulOperation`.
- This change might improve compile-time performance by avoiding unnecessary thread safety checks.