### PR TITLE
Support IntelliJ IDEA development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,6 @@ iOSInjectionProject/
 *.xcbkptlist
 /Frameworks/Cartfile.resolved
 Frameworks/Carthage/Checkouts
+
+# JetBrains IDEs
+.idea/

--- a/.run/Latest (Build).run.xml
+++ b/.run/Latest (Build).run.xml
@@ -1,0 +1,12 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Latest (Build)" type="ShConfigurationType">
+    <option name="SCRIPT_PATH" value="$PROJECT_DIR$/scripts/intellij-build.sh" />
+    <option name="SCRIPT_OPTIONS" value="" />
+    <option name="SCRIPT_WORKING_DIRECTORY" value="$PROJECT_DIR$" />
+    <option name="INTERPRETER_PATH" value="" />
+    <option name="INTERPRETER_OPTIONS" value="" />
+    <option name="EXECUTE_IN_TERMINAL" value="true" />
+    <option name="EXECUTE_SCRIPT_FILE" value="true" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/Latest (Run).run.xml
+++ b/.run/Latest (Run).run.xml
@@ -1,0 +1,12 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Latest (Run)" type="ShConfigurationType">
+    <option name="SCRIPT_PATH" value="$PROJECT_DIR$/scripts/intellij-run.sh" />
+    <option name="SCRIPT_OPTIONS" value="" />
+    <option name="SCRIPT_WORKING_DIRECTORY" value="$PROJECT_DIR$" />
+    <option name="INTERPRETER_PATH" value="" />
+    <option name="INTERPRETER_OPTIONS" value="" />
+    <option name="EXECUTE_IN_TERMINAL" value="true" />
+    <option name="EXECUTE_SCRIPT_FILE" value="true" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/README.md
+++ b/README.md
@@ -32,6 +32,11 @@ You can build Latest directly on your machine. To do that, you have to download 
 
 Then you can open the `Latest.xcodeproj` and hit *Build and Run*. Make sure that the `Latest` scheme is selected.
 
+### Build from IntelliJ IDEA
+
+If you prefer JetBrains tooling, this repository also includes shared run configurations for IntelliJ IDEA.
+Open the project in IntelliJ IDEA and use either `Latest (Build)` or `Latest (Run)`. Both configurations call the shell scripts in [`scripts/`](./scripts), which build the Xcode project through `xcodebuild`.
+
 ## Contribution
 
 I am thankful for all contributions to the project. You can contribute typo-fixes, translations, code and of course suggestions, wishes, and bug reports.

--- a/scripts/intellij-build.sh
+++ b/scripts/intellij-build.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PROJECT_PATH="$ROOT_DIR/Latest.xcodeproj"
+SCHEME_NAME="Latest"
+BUILD_CONFIGURATION="${BUILD_CONFIGURATION:-Debug}"
+DERIVED_DATA_PATH="${DERIVED_DATA_PATH:-$ROOT_DIR/build/intellij-derived-data}"
+
+resolve_xcodebuild() {
+  if /usr/bin/xcrun --find xcodebuild >/dev/null 2>&1; then
+    return 0
+  fi
+
+  local -a candidates=(
+    "${XCODE_APP_PATH:-}"
+    "/Applications/Xcode.app"
+    "/Applications/Xcode-beta.app"
+  )
+
+  local candidate
+  for candidate in "${candidates[@]}"; do
+    if [[ -n "$candidate" && -d "$candidate/Contents/Developer" ]]; then
+      export DEVELOPER_DIR="$candidate/Contents/Developer"
+      if /usr/bin/xcrun --find xcodebuild >/dev/null 2>&1; then
+        return 0
+      fi
+    fi
+  done
+
+  cat >&2 <<'EOF'
+Unable to find Xcode's build tools.
+
+Install Xcode and make sure the active developer directory points at it:
+  sudo xcode-select -s /Applications/Xcode.app/Contents/Developer
+
+If Xcode is installed somewhere else, set XCODE_APP_PATH before running this script.
+EOF
+  return 1
+}
+
+resolve_xcodebuild
+
+mkdir -p "$DERIVED_DATA_PATH"
+
+/usr/bin/xcrun xcodebuild \
+  -project "$PROJECT_PATH" \
+  -scheme "$SCHEME_NAME" \
+  -configuration "$BUILD_CONFIGURATION" \
+  -derivedDataPath "$DERIVED_DATA_PATH" \
+  -destination "platform=macOS" \
+  CODE_SIGNING_ALLOWED=NO \
+  CODE_SIGNING_REQUIRED=NO \
+  CODE_SIGN_IDENTITY="" \
+  build \
+  "$@"

--- a/scripts/intellij-run.sh
+++ b/scripts/intellij-run.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BUILD_CONFIGURATION="${BUILD_CONFIGURATION:-Debug}"
+DERIVED_DATA_PATH="${DERIVED_DATA_PATH:-$ROOT_DIR/build/intellij-derived-data}"
+APP_PATH="$DERIVED_DATA_PATH/Build/Products/$BUILD_CONFIGURATION/Latest.app"
+
+"$ROOT_DIR/scripts/intellij-build.sh" "$@"
+
+if [[ ! -d "$APP_PATH" ]]; then
+  echo "Expected app bundle was not produced at $APP_PATH" >&2
+  exit 1
+fi
+
+/usr/bin/open -n "$APP_PATH"


### PR DESCRIPTION
## Summary
- add shared IntelliJ IDEA build and run configurations
- add helper scripts that build and launch the app through xcodebuild
- document the JetBrains-based workflow and ignore local .idea state

## Testing
- bash -n scripts/intellij-build.sh
- bash -n scripts/intellij-run.sh