### PR TITLE
Add support-status sorting

### DIFF
--- a/Latest/Interface/Base.lproj/Main.storyboard
+++ b/Latest/Interface/Base.lproj/Main.storyboard
@@ -804,7 +804,7 @@
                                 </textFieldCell>
                             </textField>
                             <searchField wantsLayer="YES" focusRingType="none" verticalHuggingPriority="750" textCompletion="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pFN-sP-y2s" customClass="UpdateSearchField" customModule="Latest" customModuleProvider="target">
-                                <rect key="frame" x="20" y="201" width="360" height="30"/>
+                                <rect key="frame" x="20" y="201" width="233" height="30"/>
                                 <searchFieldCell key="cell" controlSize="large" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" continuous="YES" borderStyle="bezel" usesSingleLineMode="YES" bezelStyle="round" sendsSearchStringImmediately="YES" id="8t3-jj-ywQ">
                                     <font key="font" metaFont="system"/>
                                     <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -814,6 +814,21 @@
                                     <action selector="searchFieldTextDidChange:" target="4DM-RB-IVI" id="Yqb-GN-rQ9"/>
                                 </connections>
                             </searchField>
+                            <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="oTq-0R-A3x">
+                                <rect key="frame" x="261" y="201" width="119" height="26"/>
+                                <popUpButtonCell key="cell" type="popup" bezelStyle="rounded" imagePosition="left" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" inset="2" selectedItem="vXp-UQ-4lI" id="gL9-3E-6P4">
+                                    <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
+                                    <font key="font" metaFont="menu"/>
+                                    <menu key="menu" autoenablesItems="NO" id="A4r-WT-lWE">
+                                        <items>
+                                            <menuItem title="Sort" id="vXp-UQ-4lI"/>
+                                        </items>
+                                    </menu>
+                                </popUpButtonCell>
+                                <connections>
+                                    <action selector="changeSortOrderFromPopup:" target="4DM-RB-IVI" id="ACc-DU-eMQ"/>
+                                </connections>
+                            </popUpButton>
                         </subviews>
                         <constraints>
                             <constraint firstItem="zLf-Z1-wsn" firstAttribute="top" secondItem="JKX-qd-RUY" secondAttribute="top" id="Ca2-sY-MWm"/>
@@ -824,17 +839,20 @@
                             <constraint firstAttribute="trailing" secondItem="yos-E7-CDu" secondAttribute="trailing" id="QOn-lW-jBV"/>
                             <constraint firstItem="zLf-Z1-wsn" firstAttribute="leading" secondItem="JKX-qd-RUY" secondAttribute="leading" id="VRY-sw-t9v"/>
                             <constraint firstItem="gUd-I6-M7r" firstAttribute="leading" secondItem="JKX-qd-RUY" secondAttribute="leading" constant="20" id="Z5d-wf-g7W"/>
+                            <constraint firstItem="oTq-0R-A3x" firstAttribute="centerY" secondItem="pFN-sP-y2s" secondAttribute="centerY" id="aPH-H1-K2G"/>
                             <constraint firstItem="pFN-sP-y2s" firstAttribute="top" secondItem="zLf-Z1-wsn" secondAttribute="bottom" constant="8" symbolic="YES" id="ayY-zN-ich"/>
+                            <constraint firstItem="oTq-0R-A3x" firstAttribute="leading" secondItem="pFN-sP-y2s" secondAttribute="trailing" constant="8" symbolic="YES" id="cq8-c2-hF9"/>
                             <constraint firstAttribute="trailing" secondItem="zLf-Z1-wsn" secondAttribute="trailing" id="gSz-1J-Go1"/>
                             <constraint firstItem="yos-E7-CDu" firstAttribute="top" secondItem="pFN-sP-y2s" secondAttribute="bottom" constant="8" symbolic="YES" id="mOK-h5-sYO"/>
                             <constraint firstAttribute="trailing" secondItem="gUd-I6-M7r" secondAttribute="trailing" constant="20" id="txJ-69-wQL"/>
                             <constraint firstAttribute="bottom" secondItem="yos-E7-CDu" secondAttribute="bottom" constant="-1" id="ue4-dZ-PoH"/>
-                            <constraint firstAttribute="trailing" secondItem="pFN-sP-y2s" secondAttribute="trailing" constant="20" symbolic="YES" id="zvh-EW-8CN"/>
+                            <constraint firstAttribute="trailing" secondItem="oTq-0R-A3x" secondAttribute="trailing" constant="20" symbolic="YES" id="zvh-EW-8CN"/>
                         </constraints>
                     </view>
                     <connections>
                         <outlet property="placeholderLabel" destination="gUd-I6-M7r" id="NGo-VL-QyQ"/>
                         <outlet property="searchField" destination="pFN-sP-y2s" id="x6z-RR-xrS"/>
+                        <outlet property="sortOrderPopupButton" destination="oTq-0R-A3x" id="VDU-8r-yfl"/>
                         <outlet property="tableView" destination="Aue-8r-EWw" id="Kk8-bt-uhk"/>
                         <outlet property="tableViewMenu" destination="Ake-Tt-cX3" id="9e8-6Q-FyL"/>
                         <outlet property="updatesLabel" destination="C1U-Xt-po9" id="gYG-qf-IaS"/>

--- a/Latest/Interface/Main Window/Update Table View/Controller/UpdateTableView+Search.swift
+++ b/Latest/Interface/Main Window/Update Table View/Controller/UpdateTableView+Search.swift
@@ -18,6 +18,42 @@ class UpdateSearchField: NSSearchField {
 }
 
 extension UpdateTableViewController {
+
+	func configureSortOrderPopupButton() {
+		sortOrderPopupButton.removeAllItems()
+		sortOrderPopupButton.menu?.autoenablesItems = false
+
+		AppListSettings.SortOptions.allCases.forEach { order in
+			let item = order.menuItem(
+				target: nil,
+				action: nil,
+				isSelected: AppListSettings.shared.sortOrder == order
+			)
+			item.isEnabled = true
+			sortOrderPopupButton.menu?.addItem(item)
+		}
+
+		updateSortOrderPopupButtonSelection()
+	}
+
+	func updateSortOrderPopupButtonSelection() {
+		let selectedSortOrder = AppListSettings.shared.sortOrder
+		guard let item = sortOrderPopupButton.itemArray.first(where: {
+			($0.representedObject as? AppListSettings.SortOptions) == selectedSortOrder
+		}) else {
+			return
+		}
+
+		sortOrderPopupButton.select(item)
+	}
+
+	@IBAction func changeSortOrderFromPopup(_ sender: NSPopUpButton) {
+		guard let selectedSortOrder = sender.selectedItem?.representedObject as? AppListSettings.SortOptions else {
+			return
+		}
+
+		AppListSettings.shared.sortOrder = selectedSortOrder
+	}
 	
 	@IBAction func searchFieldTextDidChange(_ sender: NSSearchField) {
 		var searchQuery: String? = sender.stringValue

--- a/Latest/Interface/Main Window/Update Table View/Controller/UpdateTableViewController.swift
+++ b/Latest/Interface/Main Window/Update Table View/Controller/UpdateTableViewController.swift
@@ -66,6 +66,8 @@ class UpdateTableViewController: NSViewController, NSMenuItemValidation, NSTable
         if let cell = tableView.makeView(withIdentifier: NSUserInterfaceItemIdentifier(rawValue: "MLMUpdateCellIdentifier"), owner: self) {
             self.tableView.rowHeight = cell.frame.height
         }
+
+		self.configureSortOrderPopupButton()
                         
         self.tableViewMenu.delegate = self
         self.tableView.menu = self.tableViewMenu
@@ -87,9 +89,10 @@ class UpdateTableViewController: NSViewController, NSMenuItemValidation, NSTable
 		
 		// Setup title
 		self.updateTitleAndBatch()
-		
-		// Setup search field
+
+		// Keep the search field below the titlebar controls in the unified window style.
         NSLayoutConstraint(item: self.searchField!, attribute: .top, relatedBy: .equal, toItem: self.view.window?.contentLayoutGuide, attribute: .top, multiplier: 1.0, constant: 1).isActive = true
+
 		self.view.window?.makeFirstResponder(nil)
 	}
 	
@@ -104,6 +107,7 @@ class UpdateTableViewController: NSViewController, NSMenuItemValidation, NSTable
     @IBOutlet weak var tableView: NSTableView!
     
 	func updateSnapshot() {
+		self.updateSortOrderPopupButtonSelection()
 		self.scheduleTableViewUpdate(with: self.snapshot.updated(), animated: true)
 		self.updateTitleAndBatch()
 	}
@@ -374,7 +378,7 @@ class UpdateTableViewController: NSViewController, NSMenuItemValidation, NSTable
         guard let action = menuItem.action else {
             return true
         }
-        
+
 		let index = self.rowIndex(forMenuItem: menuItem)
 		guard index >= 0, let app = self.snapshot.app(at: index) else {
 			return false
@@ -413,6 +417,9 @@ class UpdateTableViewController: NSViewController, NSMenuItemValidation, NSTable
 	
 	/// The search field used for filtering apps
 	@IBOutlet weak var searchField: NSSearchField!
+
+	/// The dropdown used for selecting the current sort mode.
+	@IBOutlet weak var sortOrderPopupButton: NSPopUpButton!
 	
 	
 	// MARK: - Actions

--- a/Latest/Interface/Main Window/Window Controllers/MainWindowController.swift
+++ b/Latest/Interface/Main Window/Window Controllers/MainWindowController.swift
@@ -155,11 +155,11 @@ class MainWindowController: NSWindowController, NSMenuItemValidation, NSMenuDele
 	
 	private var sortByMenuItems: [NSMenuItem] {
 		AppListSettings.SortOptions.allCases.map { order in
-			let item = NSMenuItem(title: order.displayName, action: #selector(changeSortOrder), keyEquivalent: "")
-			item.representedObject = order
-			item.state = AppListSettings.shared.sortOrder == order ? .on : .off
-			
-			return item
+			order.menuItem(
+				target: self,
+				action: #selector(changeSortOrder),
+				isSelected: AppListSettings.shared.sortOrder == order
+			)
 		}
 	}
     

--- a/Latest/Model/App.swift
+++ b/Latest/Model/App.swift
@@ -113,6 +113,11 @@ extension App {
 	var supported: Bool {
 		return self.source != .none
 	}
+
+	/// The support level of the app within Latest.
+	var supportState: Source.SupportState {
+		return self.source.supportState
+	}
 	
 	/// The date of the app when it was last updated.
 	var updateDate: Date {

--- a/Latest/Model/Source.swift
+++ b/Latest/Model/Source.swift
@@ -87,6 +87,18 @@ extension App.Source {
 // MARK: Accessors
 
 extension App.Source.SupportState {
+	/// A stable sort rank used for ordering apps by support status.
+	var sortPriority: Int {
+		switch self {
+		case .full:
+			return 0
+		case .limited:
+			return 1
+		case .none:
+			return 2
+		}
+	}
+
 	/// Returns an image using the system status indicator (colored dot) for the given status.
 	var statusImage: NSImage {
 		let name = switch self {

--- a/Latest/Resources/en.lproj/Localizable.strings
+++ b/Latest/Resources/en.lproj/Localizable.strings
@@ -76,6 +76,9 @@
 /* Sorting option to list by app names alphabetically. Displayed in menu with title: 'Sort By' -> 'Name' */
 "NameSortOption" = "Name";
 
+/* Sorting option to group apps by support level. Displayed in menu with title: 'Sort By' -> 'Support' */
+"SupportStatusSortOption" = "Support";
+
 /* Description of release notes empty state */
 "NoAppSelectedDescription" = "Select an app from the list to read its release notes.";
 

--- a/Latest/View Model/AppListSettings.swift
+++ b/Latest/View Model/AppListSettings.swift
@@ -6,6 +6,8 @@
 //  Copyright © 2022 Max Langer. All rights reserved.
 //
 
+import AppKit
+
 private let SortOptionsKey = "SortOptionsKey"
 private let ShowInstalledUpdatesKey = "ShowInstalledUpdatesKey"
 private let ShowIgnoredUpdatesKey = "ShowIgnoredUpdatesKey"
@@ -23,6 +25,9 @@ struct AppListSettings: Observable {
 		
 		/// Sort alphabetically by app name.
 		case name = 1
+
+		/// Sort by whether an app is fully supported, has limited support, or is unsupported.
+		case supportStatus = 2
 		
 		/// A user-displayable text of the given sort option.
 		var displayName: String {
@@ -31,6 +36,8 @@ struct AppListSettings: Observable {
 				return NSLocalizedString("DateSortOption", comment: "Update date sorting option. Displayed in menu with title: 'Sort By' -> 'Date'")
 			case .name:
 				return NSLocalizedString("NameSortOption", comment: "Sorting option to list by app names alphabetically. Displayed in menu with title: 'Sort By' -> 'Name'")
+			case .supportStatus:
+				return NSLocalizedString("SupportStatusSortOption", comment: "Sorting option to group apps by support level. Displayed in menu with title: 'Sort By' -> 'Support'")
 			}
 		}
 	}
@@ -112,4 +119,15 @@ struct AppListSettings: Observable {
 		}
 	}
 	
+}
+
+extension AppListSettings.SortOptions {
+	/// Returns a menu item representing the sort option.
+	func menuItem(target: AnyObject?, action: Selector?, isSelected: Bool = false) -> NSMenuItem {
+		let item = NSMenuItem(title: self.displayName, action: action, keyEquivalent: "")
+		item.target = target
+		item.representedObject = self
+		item.state = isSelected ? .on : .off
+		return item
+	}
 }

--- a/Latest/View Model/AppListSnapshot.swift
+++ b/Latest/View Model/AppListSnapshot.swift
@@ -81,6 +81,12 @@ struct AppListSnapshot {
 				return app1.updateDate > app2.updateDate
 			case .name:
 				return app1.name.lowercased() < app2.name.lowercased()
+			case .supportStatus:
+				if app1.supportState != app2.supportState {
+					return app1.supportState.sortPriority < app2.supportState.sortPriority
+				}
+
+				return app1.name.localizedCaseInsensitiveCompare(app2.name) == .orderedAscending
 			}
 		})
 		


### PR DESCRIPTION
## Summary
- add a new sort mode that groups apps by support status
- add a sort dropdown next to the search field for quicker access
- reuse shared sort item creation between the View menu and the dropdown

Closes #554.

## Testing
- xcodebuild -project Latest.xcodeproj -scheme Latest -configuration Debug -derivedDataPath /tmp/latest-support-sort-ui -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY='' build
- manual verification of the new support sort from both the View menu and the dropdown next to search