### PR TITLE
Avoid crashing when app directories cannot be observed

### DIFF
--- a/Latest.xcodeproj/project.pbxproj
+++ b/Latest.xcodeproj/project.pbxproj
@@ -44,6 +44,7 @@
 		5087CD2D22F6E06B0013354C /* SparkleUpdateOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5087CD2C22F6E06B0013354C /* SparkleUpdateOperation.swift */; };
 		508A40552D56962400A02DF1 /* SupportStatusButtonCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 508A40542D56961400A02DF1 /* SupportStatusButtonCell.swift */; };
 		5093EF9C2B913A1C0041E6C1 /* AppDirectoryCellView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5093EF9B2B913A1C0041E6C1 /* AppDirectoryCellView.swift */; };
+		5093EF9E2D7D6D140041E6C1 /* AppDirectoryTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5093EF9D2D7D6D140041E6C1 /* AppDirectoryTest.swift */; };
 		509512141FF362A1003D2D7F /* Version.swift in Sources */ = {isa = PBXBuildFile; fileRef = 509512101FF362A1003D2D7F /* Version.swift */; };
 		509512151FF362A1003D2D7F /* Update.swift in Sources */ = {isa = PBXBuildFile; fileRef = 509512111FF362A1003D2D7F /* Update.swift */; };
 		509512221FF36301003D2D7F /* Bundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5095121F1FF36301003D2D7F /* Bundle.swift */; };
@@ -211,6 +212,7 @@
 		5087CD2C22F6E06B0013354C /* SparkleUpdateOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SparkleUpdateOperation.swift; sourceTree = "<group>"; };
 		508A40542D56961400A02DF1 /* SupportStatusButtonCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportStatusButtonCell.swift; sourceTree = "<group>"; };
 		5093EF9B2B913A1C0041E6C1 /* AppDirectoryCellView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDirectoryCellView.swift; sourceTree = "<group>"; };
+		5093EF9D2D7D6D140041E6C1 /* AppDirectoryTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDirectoryTest.swift; sourceTree = "<group>"; };
 		5094821C27C19E4A00EC6B6B /* CFBundle_Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CFBundle_Private.h; sourceTree = "<group>"; };
 		5094823327C19F5800EC6B6B /* Latest Bridging_Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Latest Bridging_Header.h"; sourceTree = "<group>"; };
 		509512101FF362A1003D2D7F /* Version.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Version.swift; sourceTree = "<group>"; };
@@ -640,6 +642,7 @@
 		50C81D6A1FBADC5900324C2E /* Tests */ = {
 			isa = PBXGroup;
 			children = (
+				5093EF9D2D7D6D140041E6C1 /* AppDirectoryTest.swift */,
 				50C81D6D1FBADC5900324C2E /* Info.plist */,
 				50FEB87C2B1BE630006FB75D /* OSVersionTest.swift */,
 				50C81D731FBADC9100324C2E /* VersionTest.swift */,
@@ -995,6 +998,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				5093EF9E2D7D6D140041E6C1 /* AppDirectoryTest.swift in Sources */,
 				50C81D741FBADC9100324C2E /* VersionTest.swift in Sources */,
 				50FEB87D2B1BE630006FB75D /* OSVersionTest.swift in Sources */,
 				50FEB87F2B1BE67F006FB75D /* VersionSanitizationTest.swift in Sources */,

--- a/Latest/Model/Directory/AppDirectory.swift
+++ b/Latest/Model/Directory/AppDirectory.swift
@@ -10,6 +10,8 @@ import Cocoa
 
 /// The folder listener listens for changes in the given directory and then runs the update checker on changes
 class AppDirectory {
+
+	typealias DescriptorProvider = (URL) -> CInt
 	
 	/// The url on which the listener reacts to changes on
 	let url : URL
@@ -29,41 +31,51 @@ class AppDirectory {
 	/// The queue on which updates to the collection are being performed.
 	private var collectionQueue = DispatchQueue(label: "DataStoreQueue")
 
+	private let descriptorProvider: DescriptorProvider
+
 	
 	/// The file system listener
-	private lazy var listener : DispatchSourceFileSystemObject = {
-		let descriptor = open((self.url as NSURL).fileSystemRepresentation, O_EVTONLY)
-		guard descriptor != -1 else { fatalError("Unable to open folder at url") }
+	private lazy var listener: DispatchSourceFileSystemObject? = {
+		let descriptor = descriptorProvider(url)
+		guard descriptor != -1 else { return nil }
 		
 		let source = DispatchSource.makeFileSystemObjectSource(fileDescriptor: descriptor,
 															   eventMask: .write)
 		
 		source.setEventHandler(handler: collectBundles)
+		source.setCancelHandler {
+			close(descriptor)
+		}
 		
 		return source
 	}()
 	
 	/// Initializes the class and resumes the listener automatically
-	init(url: URL, updateHandler: @escaping UpdateHandler) {
+	init(url: URL, updateHandler: @escaping UpdateHandler, descriptorProvider: @escaping DescriptorProvider = AppDirectory.openDescriptor) {
 		self.url = url
 		self.handler = updateHandler
+		self.descriptorProvider = descriptorProvider
 		
 		resumeTracking()
 	}
 	
 	deinit {
-		listener.cancel()
+		listener?.cancel()
 	}
 	
 	/// Resumes tracking if it is not already running
 	private func resumeTracking() {
-		listener.activate()
+		listener?.activate()
 		collectBundles()
 	}
 	
 	/// Triggers an update run
 	private func collectBundles() {
 		bundles = BundleCollector.collectBundles(at: self.url)
+	}
+
+	private static func openDescriptor(for url: URL) -> CInt {
+		open((url as NSURL).fileSystemRepresentation, O_EVTONLY)
 	}
 	
 }

--- a/Tests/AppDirectoryTest.swift
+++ b/Tests/AppDirectoryTest.swift
@@ -1,0 +1,30 @@
+//
+//  AppDirectoryTest.swift
+//  Latest Tests
+//
+//  Created by Codex on 2026-03-15.
+//
+
+import XCTest
+@testable import Latest
+
+final class AppDirectoryTest: XCTestCase {
+
+	func testInitFallsBackToSingleScanWhenDirectoryCannotBeObserved() throws {
+		let url = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+		try FileManager.default.createDirectory(at: url, withIntermediateDirectories: false)
+		defer {
+			try? FileManager.default.removeItem(at: url)
+		}
+
+		let updateExpectation = expectation(description: "directory scan completes")
+
+		let directory = AppDirectory(url: url, updateHandler: {
+			updateExpectation.fulfill()
+		}, descriptorProvider: { _ in -1 })
+
+		wait(for: [updateExpectation], timeout: 1)
+		XCTAssertEqual(directory.bundles.count, 0)
+	}
+
+}


### PR DESCRIPTION
This change makes startup resilient when Latest cannot attach a filesystem observer to one of the configured scan directories.

What changed:
- stop calling `fatalError` if opening a watched app directory fails
- still perform a one-time scan of that directory so launch can continue
- add a regression test for the degraded path

Why:
- issue #533 reports the app window disappearing immediately after launch
- I reproduced a launch-time crash in background scanning, though with a persisted custom scan path on my machine
- this does not prove it is the reporter's exact root cause, but it matches the observed timing and crash shape much better than the `OBJC_DISABLE_INITIALIZE_FORK_SAFETY` theory

Verification:
- `xcodebuild -project Latest.xcodeproj -scheme Latest -configuration Debug CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY= build`\n- direct launch no longer crashes in `AppDirectory.swift` for the reproduced case\n\nNote:\n- the existing test target currently fails to build in my environment because Xcode cannot resolve `CommerceKit` / `StoreFoundation` from the test target, so I could not run the full test suite end-to-end.