### PR TITLE
Work around broken MAS installs on recent macOS

### DIFF
--- a/Latest/Model/Update Checker Extensions/App Store/MacAppStoreCheckerOperation.swift
+++ b/Latest/Model/Update Checker Extensions/App Store/MacAppStoreCheckerOperation.swift
@@ -89,6 +89,40 @@ class MacAppStoreUpdateCheckerOperation: StatefulOperation, UpdateCheckerOperati
 		let path = receiptPath(forAppAt: url)
 		return path?.contains("WrappedBundle") ?? false
 	}
+
+	/// Returns whether built-in MAS installs are affected by Apple's PackageKit change.
+	///
+	/// The affected releases were first reported on macOS 14.8.2, 15.7.2, and 26.1.
+	///
+	/// We treat those as lower bounds because Apple shipped a PackageKit security hardening
+	/// in that release batch, so later releases are expected to keep the same restriction.
+	static func requiresExternalUpdateWorkaround(for version: OperatingSystemVersion = ProcessInfo.processInfo.operatingSystemVersion) -> Bool {
+		if version.majorVersion > 26 {
+			return true
+		}
+		
+		if version.majorVersion == 26 {
+			return version.minorVersion >= 1
+		}
+		
+		if version.majorVersion == 15 {
+			if version.minorVersion > 7 {
+				return true
+			}
+			
+			return version.minorVersion == 7 && version.patchVersion >= 2
+		}
+		
+		if version.majorVersion == 14 {
+			if version.minorVersion > 8 {
+				return true
+			}
+			
+			return version.minorVersion == 8 && version.patchVersion >= 2
+		}
+		
+		return false
+	}
 	
 }
 
@@ -97,8 +131,8 @@ extension MacAppStoreUpdateCheckerOperation {
 	/// Returns a proper update object from the given app store entry.
 	private func update(from entry: AppStoreEntry) -> App.Update {
 		let version = Version(versionNumber: entry.versionNumber, buildNumber: nil)
-		let action: App.Update.Action = if Self.isIOSAppBundle(at: app.fileURL) {
-			// iOS Apps: Open App Store page where the user can update manually. The update operation does not work for them.
+		let action: App.Update.Action = if Self.isIOSAppBundle(at: app.fileURL) || Self.requiresExternalUpdateWorkaround() {
+			// iOS apps and affected macOS versions must update in the App Store.
 			.external(label: NSLocalizedString("AppStoreSource", comment: "The source name of apps loaded from the App Store."), block: { app in
 				NSWorkspace.shared.open(entry.pageURL)
 			})

--- a/Tests/OSVersionTest.swift
+++ b/Tests/OSVersionTest.swift
@@ -37,5 +37,18 @@ class OSVersionTest: XCTestCase {
 		XCTAssertThrowsError(try OperatingSystemVersion(string: ""))
 		XCTAssertThrowsError(try OperatingSystemVersion(string: "Version"))
 	}
+
+	func testMacAppStoreWorkaroundVersions() {
+		XCTAssertFalse(MacAppStoreUpdateCheckerOperation.requiresExternalUpdateWorkaround(for: OperatingSystemVersion(majorVersion: 14, minorVersion: 8, patchVersion: 1)))
+		XCTAssertTrue(MacAppStoreUpdateCheckerOperation.requiresExternalUpdateWorkaround(for: OperatingSystemVersion(majorVersion: 14, minorVersion: 8, patchVersion: 2)))
+		XCTAssertTrue(MacAppStoreUpdateCheckerOperation.requiresExternalUpdateWorkaround(for: OperatingSystemVersion(majorVersion: 14, minorVersion: 8, patchVersion: 3)))
+		XCTAssertFalse(MacAppStoreUpdateCheckerOperation.requiresExternalUpdateWorkaround(for: OperatingSystemVersion(majorVersion: 15, minorVersion: 7, patchVersion: 1)))
+		XCTAssertTrue(MacAppStoreUpdateCheckerOperation.requiresExternalUpdateWorkaround(for: OperatingSystemVersion(majorVersion: 15, minorVersion: 7, patchVersion: 2)))
+		XCTAssertTrue(MacAppStoreUpdateCheckerOperation.requiresExternalUpdateWorkaround(for: OperatingSystemVersion(majorVersion: 15, minorVersion: 8, patchVersion: 0)))
+		XCTAssertFalse(MacAppStoreUpdateCheckerOperation.requiresExternalUpdateWorkaround(for: OperatingSystemVersion(majorVersion: 26, minorVersion: 0, patchVersion: 0)))
+		XCTAssertTrue(MacAppStoreUpdateCheckerOperation.requiresExternalUpdateWorkaround(for: OperatingSystemVersion(majorVersion: 26, minorVersion: 1, patchVersion: 0)))
+		XCTAssertTrue(MacAppStoreUpdateCheckerOperation.requiresExternalUpdateWorkaround(for: OperatingSystemVersion(majorVersion: 26, minorVersion: 2, patchVersion: 0)))
+		XCTAssertTrue(MacAppStoreUpdateCheckerOperation.requiresExternalUpdateWorkaround(for: OperatingSystemVersion(majorVersion: 27, minorVersion: 0, patchVersion: 0)))
+	}
 	
 }


### PR DESCRIPTION
## Summary

This is an intermediate workaround for #514.

Latest currently handles Mac App Store updates by:
- detecting MAS apps via the presence of an App Store receipt
- checking the App Store metadata via `MacAppStoreUpdateCheckerOperation`
- performing the update in-app via `MacAppStoreUpdateOperation`, which uses `CKPurchaseController` to start the CommerceKit install flow

That built-in install path now fails on recent macOS releases. The user-visible result is the `PKInstallErrorDomain Code=201` failure discussed in #514, and in some cases damaged or duplicated apps after repeated retries.

## What this PR changes

For affected macOS versions, Latest now stops offering the built-in MAS update action and falls back to opening the app's App Store page instead.

The workaround is applied as a lower-bound gate, not just for the exact versions first reported in the issue:
- `14.8.2+`
- `15.7.2+`
- `26.1+`

That means later patch/minor releases on those branches, and future major releases after `26`, also use the external App Store fallback until we have a proper replacement install path.

## Why broaden the gate

The current evidence suggests those versions are the start of Apple's new PackageKit behavior, not isolated broken releases:
- Apple's security notes for macOS Sonoma 14.8.2, Sequoia 15.7.2, and Tahoe 26.1 all include the same PackageKit fix (`CVE-2025-43411`) described as adding entitlement checks.
- The `mas` project hit the same breakage and converged on the same lower bounds for its workaround.

Given that, a narrower "only these exact versions" check would likely miss later releases that keep the same restriction.

## Verification

Built successfully with:

```sh
xcodebuild build -project Latest.xcodeproj -scheme Latest -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=''
```

I also tried a focused `OSVersionTest` run, but the existing test target still fails to resolve the private `CommerceKit` and `StoreFoundation` module dependencies, so I could not run that test bundle in this environment.

## Follow-up for the real fix

This is only a mitigation. The proper fix should replace the broken install step rather than redirecting users to the App Store.

The likely shape is:
- keep CommerceKit only for the download step
- preserve the downloaded `.pkg` and sibling receipt before `storedownloadd` removes them
- install the pkg through a privileged helper using `/usr/sbin/installer -pkg ... -target /`
- restore the captured receipt into `App.app/Contents/_MASReceipt/receipt`
- set receipt ownership to `root:wheel`
- refresh metadata afterwards, for example with `mdimport`

## References

- #514
- Apple security notes for macOS Sonoma 14.8.2: https://support.apple.com/en-us/125636
- Apple security notes for macOS Sequoia 15.7.2: https://support.apple.com/en-us/125635
- Apple security notes for macOS Tahoe 26.1: https://support.apple.com/en-us/125634
- `mas` issue: https://github.com/mas-cli/mas/issues/1029
- `mas` workaround PR: https://github.com/mas-cli/mas/pull/1041
