### PR TITLE
Prevent duplicate startup dispatch-group completion

### DIFF
--- a/Latest/Model/Directory/AppLibrary.swift
+++ b/Latest/Model/Directory/AppLibrary.swift
@@ -54,23 +54,38 @@ class AppLibrary {
 	}
 		
 	private func setupDirectoryObservers() {
-		// Use a dispatch group for the initial setup to get contents for all directories before gathering apps
-		var dispatchGroup: DispatchGroup? = self.directories.isEmpty ? DispatchGroup() : nil
+		// Use a dispatch group for the initial setup to get contents for all directories before gathering apps.
+		// Each directory may emit multiple updates while it is being initialized, so only the first callback
+		// should fulfill the startup group.
+		let dispatchGroup = self.directories.isEmpty ? DispatchGroup() : nil
+		let existingDirectories = self.directories
 		
 		// Setup directories
 		directories = Dictionary(uniqueKeysWithValues: directoryStore.URLs.compactMap { url in
 			// Skip unreachable directories
 			guard directoryStore.isReachable(url) else { return nil }
 			
+			// Reuse existing directory observations if possible
+			if let existingDirectory = existingDirectories[url] {
+				return (url, existingDirectory)
+			}
+			
 			dispatchGroup?.enter()
 			
-			// Reuse existing directory observations if possible
-			return (url, directories[url] ?? AppDirectory(url: url) {
-				if let dispatchGroup {
-					// Initial mode, notify dispatch group
-					dispatchGroup.leave()
+			let initialLoadLock = NSLock()
+			var initialLoadCompleted = false
+			
+			return (url, AppDirectory(url: url) {
+				initialLoadLock.lock()
+				let isInitialLoad = !initialLoadCompleted
+				if isInitialLoad {
+					initialLoadCompleted = true
+				}
+				initialLoadLock.unlock()
+				
+				if isInitialLoad {
+					dispatchGroup?.leave()
 				} else {
-					// Schedule update
 					self.updateScheduler.add(data: 1)
 				}
 			})
@@ -79,7 +94,6 @@ class AppLibrary {
 		dispatchGroup?.notify(queue: .global()) {
 			// Call update immediately. Using the scheduler delays the update.
 			self.performUpdate()
-			dispatchGroup = nil
 		}
 	}
 	


### PR DESCRIPTION
## Summary
This change fixes a launch crash during the initial app-directory scan.

During startup, `AppLibrary.setupDirectoryObservers()` creates a `DispatchGroup` and expects each new `AppDirectory` to leave that group exactly once after its initial scan completes. In practice, a directory observer can emit more than one callback before startup finishes, which can call `dispatchGroup.leave()` more times than `enter()`. On recent macOS versions this trips libdispatch with `BUG IN CLIENT OF LIBDISPATCH: Unbalanced call to dispatch_group_leave()`.

This patch makes each newly created directory observer consume its startup group slot only once. Any later callbacks are routed through the existing deferred update scheduler.

Closes #465.

## Validation
- `xcodebuild build -project Latest.xcodeproj -scheme Latest -destination "platform=macOS" CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO` succeeds.
- `xcodebuild test` still fails in this environment because the test target cannot resolve the private `CommerceKit` and `StoreFoundation` modules.