### PR TITLE
Fix missed refreshes for apps in subfolders

### DIFF
--- a/Latest.xcodeproj/project.pbxproj
+++ b/Latest.xcodeproj/project.pbxproj
@@ -77,6 +77,7 @@
 		50DAEF4421047FA900B32E8A /* UpdateItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50DAEF4321047FA900B32E8A /* UpdateItemView.swift */; };
 		50E4EB072B17DACB00A70A7D /* VersionParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50E4EB062B17DACB00A70A7D /* VersionParser.swift */; };
 		50E4EB092B17DFCE00A70A7D /* VersionParserTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50E4EB082B17DFCE00A70A7D /* VersionParserTest.swift */; };
+		50F0AA112D7B1234006ABCD1 /* AppDirectoryTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F0AA102D7B1234006ABCD1 /* AppDirectoryTest.swift */; };
 		50FEB87D2B1BE630006FB75D /* OSVersionTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50FEB87C2B1BE630006FB75D /* OSVersionTest.swift */; };
 		50FEB87F2B1BE67F006FB75D /* VersionSanitizationTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50FEB87E2B1BE67E006FB75D /* VersionSanitizationTest.swift */; };
 		50FEB8812B1D2402006FB75D /* ExcludedAppIdentifiers.plist in Resources */ = {isa = PBXBuildFile; fileRef = 50FEB8802B1D2402006FB75D /* ExcludedAppIdentifiers.plist */; };
@@ -299,6 +300,7 @@
 		50DAEF4321047FA900B32E8A /* UpdateItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateItemView.swift; sourceTree = "<group>"; };
 		50E4EB062B17DACB00A70A7D /* VersionParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VersionParser.swift; sourceTree = "<group>"; };
 		50E4EB082B17DFCE00A70A7D /* VersionParserTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VersionParserTest.swift; sourceTree = "<group>"; };
+		50F0AA102D7B1234006ABCD1 /* AppDirectoryTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDirectoryTest.swift; sourceTree = "<group>"; };
 		50E65CDD247A84BC00DFEB47 /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/Main.strings; sourceTree = "<group>"; };
 		50E65CDE247A84E700DFEB47 /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = fr; path = fr.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
 		50E65CE0247A84F300DFEB47 /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -641,6 +643,7 @@
 			isa = PBXGroup;
 			children = (
 				50C81D6D1FBADC5900324C2E /* Info.plist */,
+				50F0AA102D7B1234006ABCD1 /* AppDirectoryTest.swift */,
 				50FEB87C2B1BE630006FB75D /* OSVersionTest.swift */,
 				50C81D731FBADC9100324C2E /* VersionTest.swift */,
 				50E4EB082B17DFCE00A70A7D /* VersionParserTest.swift */,
@@ -995,6 +998,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				50F0AA112D7B1234006ABCD1 /* AppDirectoryTest.swift in Sources */,
 				50C81D741FBADC9100324C2E /* VersionTest.swift in Sources */,
 				50FEB87D2B1BE630006FB75D /* OSVersionTest.swift in Sources */,
 				50FEB87F2B1BE67F006FB75D /* VersionSanitizationTest.swift in Sources */,

--- a/Latest/Model/Directory/AppDirectory.swift
+++ b/Latest/Model/Directory/AppDirectory.swift
@@ -7,12 +7,13 @@
 //
 
 import Cocoa
+import CoreServices
 
 /// The folder listener listens for changes in the given directory and then runs the update checker on changes
 class AppDirectory {
 	
 	/// The url on which the listener reacts to changes on
-	let url : URL
+	let url: URL
 	
 	/// The bundles collected within this directory.
 	var bundles = [App.Bundle]() {
@@ -27,21 +28,12 @@ class AppDirectory {
 	let handler: UpdateHandler
 	
 	/// The queue on which updates to the collection are being performed.
-	private var collectionQueue = DispatchQueue(label: "DataStoreQueue")
-
+	private let collectionQueue = DispatchQueue(label: "DataStoreQueue")
 	
-	/// The file system listener
-	private lazy var listener : DispatchSourceFileSystemObject = {
-		let descriptor = open((self.url as NSURL).fileSystemRepresentation, O_EVTONLY)
-		guard descriptor != -1 else { fatalError("Unable to open folder at url") }
-		
-		let source = DispatchSource.makeFileSystemObjectSource(fileDescriptor: descriptor,
-															   eventMask: .write)
-		
-		source.setEventHandler(handler: collectBundles)
-		
-		return source
-	}()
+	/// Recursive file system listener for the tracked directory.
+	private lazy var listener = RecursiveDirectoryMonitor(url: self.url, queue: collectionQueue) { [weak self] in
+		self?.collectBundles()
+	}
 	
 	/// Initializes the class and resumes the listener automatically
 	init(url: URL, updateHandler: @escaping UpdateHandler) {
@@ -51,19 +43,83 @@ class AppDirectory {
 		resumeTracking()
 	}
 	
-	deinit {
-		listener.cancel()
-	}
-	
 	/// Resumes tracking if it is not already running
 	private func resumeTracking() {
-		listener.activate()
+		listener.start()
 		collectBundles()
 	}
 	
 	/// Triggers an update run
 	private func collectBundles() {
 		bundles = BundleCollector.collectBundles(at: self.url)
+	}
+	
+}
+
+/// Recursive directory monitor backed by FSEvents.
+private final class RecursiveDirectoryMonitor {
+	
+	typealias EventHandler = () -> Void
+	
+	private let url: URL
+	private let queue: DispatchQueue
+	private let eventHandler: EventHandler
+	private var stream: FSEventStreamRef?
+	private var isStarted = false
+	
+	init(url: URL, queue: DispatchQueue, eventHandler: @escaping EventHandler) {
+		self.url = url
+		self.queue = queue
+		self.eventHandler = eventHandler
+	}
+	
+	deinit {
+		stop()
+	}
+	
+	func start() {
+		guard !isStarted, let stream = makeStream() else { return }
+		
+		self.stream = stream
+		FSEventStreamSetDispatchQueue(stream, queue)
+		FSEventStreamStart(stream)
+		isStarted = true
+	}
+	
+	func stop() {
+		guard let stream else { return }
+		
+		FSEventStreamStop(stream)
+		FSEventStreamInvalidate(stream)
+		FSEventStreamRelease(stream)
+		self.stream = nil
+		isStarted = false
+	}
+	
+	private func makeStream() -> FSEventStreamRef? {
+		var context = FSEventStreamContext(
+			version: 0,
+			info: UnsafeMutableRawPointer(Unmanaged.passUnretained(self).toOpaque()),
+			retain: nil,
+			release: nil,
+			copyDescription: nil
+		)
+		
+		let flags = UInt32(kFSEventStreamCreateFlagUseCFTypes | kFSEventStreamCreateFlagFileEvents)
+		
+		return FSEventStreamCreate(
+			nil,
+			{ _, info, _, _, _, _ in
+				guard let info else { return }
+				let monitor = Unmanaged<RecursiveDirectoryMonitor>.fromOpaque(info).takeUnretainedValue()
+				monitor.eventHandler()
+			},
+			&context,
+			[url.path] as CFArray,
+			FSEventStreamEventId(kFSEventStreamEventIdSinceNow),
+			0.5,
+			flags
+		)
 	}
 	
 }

--- a/Tests/AppDirectoryTest.swift
+++ b/Tests/AppDirectoryTest.swift
@@ -1,0 +1,70 @@
+//
+//  AppDirectoryTest.swift
+//  Latest Tests
+//
+//  Created by Codex on 15.03.26.
+//
+
+import XCTest
+@testable import Latest
+
+class AppDirectoryTest: XCTestCase {
+	
+	func testNestedSubfolderChangesTriggerRefresh() throws {
+		let fileManager = FileManager.default
+		let rootURL = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+			.appendingPathComponent("Latest-AppDirectoryTest-\(UUID().uuidString)", isDirectory: true)
+		let nestedURL = rootURL.appendingPathComponent("Browsers", isDirectory: true)
+		
+		try fileManager.createDirectory(at: nestedURL, withIntermediateDirectories: true)
+		defer { try? fileManager.removeItem(at: rootURL) }
+		
+		let initialScan = expectation(description: "Initial scan completes")
+		let nestedChange = expectation(description: "Nested change triggers rescan")
+		
+		var callbackCount = 0
+		var directory: AppDirectory?
+		directory = AppDirectory(url: rootURL) {
+			callbackCount += 1
+			
+			if callbackCount == 1 {
+				initialScan.fulfill()
+			}
+			
+			if directory?.bundles.contains(where: { $0.name == "Nested App" }) == true {
+				nestedChange.fulfill()
+			}
+		}
+		
+		wait(for: [initialScan], timeout: 2)
+		
+		try Self.createAppBundle(
+			named: "Nested App",
+			identifier: "com.example.nested-app",
+			at: nestedURL.appendingPathComponent("Nested App.app", isDirectory: true)
+		)
+		
+		wait(for: [nestedChange], timeout: 5)
+		XCTAssertEqual(directory?.bundles.count, 1)
+		XCTAssertEqual(directory?.bundles.first?.name, "Nested App")
+	}
+	
+	private static func createAppBundle(named name: String, identifier: String, at url: URL) throws {
+		let fileManager = FileManager.default
+		let contentsURL = url.appendingPathComponent("Contents", isDirectory: true)
+		
+		try fileManager.createDirectory(at: contentsURL, withIntermediateDirectories: true)
+		
+		let infoPlist: [String: Any] = [
+			"CFBundleIdentifier": identifier,
+			"CFBundleName": name,
+			"CFBundlePackageType": "APPL",
+			"CFBundleShortVersionString": "1.0",
+			"CFBundleVersion": "1"
+		]
+		
+		let data = try PropertyListSerialization.data(fromPropertyList: infoPlist, format: .xml, options: 0)
+		try data.write(to: contentsURL.appendingPathComponent("Info.plist"))
+	}
+	
+}


### PR DESCRIPTION
Fixes #480.

## Summary
Latest already scans subfolders during the initial app discovery pass, but its live directory watcher only observes the top-level application directory. On macOS that means changes inside existing subfolders can be missed until Latest rescans or restarts.

## Root Cause
The initial scan is recursive:
- `AppDirectoryStore` adds the standard application roots (`/Applications` and `~/Applications`):
  https://github.com/mangerlahn/Latest/blob/main/Latest/Model/Directory/AppDirectoryStore.swift#L33-L37
- `BundleCollector.collectBundles` then uses `FileManager.default.enumerator(at:...)`, which walks descendants under those roots:
  https://github.com/mangerlahn/Latest/blob/main/Latest/Model/Directory/BundleCollector.swift#L28-L40

The live watcher is not recursive:
- `AppDirectory` currently opens only the root directory and attaches a `.write` `DispatchSourceFileSystemObject` to that single descriptor:
  https://github.com/mangerlahn/Latest/blob/main/Latest/Model/Directory/AppDirectory.swift#L33-L41

I reproduced that behavior locally: a write in `root/subfolder/...` did not trigger the root watcher, while a write in `root/...` did.

## Fix
- Replace the root-only `DispatchSourceFileSystemObject` watcher with a recursive FSEvents monitor in `AppDirectory`
- Keep the existing recursive bundle collection logic unchanged
- Add a regression test that creates an app bundle inside a nested subfolder and expects a refresh

## Verification
- `xcodebuild -project Latest.xcodeproj -scheme Latest -configuration Debug CODE_SIGNING_ALLOWED=NO build`
- `xcodebuild -project Latest.xcodeproj -scheme Latest -configuration Debug CODE_SIGNING_ALLOWED=NO test -only-testing:'Latest Tests/AppDirectoryTest'`

The build passed. The targeted test could not be executed locally because the existing test target failed to resolve `CommerceKit` and `StoreFoundation` when importing `Latest`.
