### PR TITLE
Fix Wireshark Sparkle updates selecting Intel builds on Apple Silicon

### DIFF
--- a/Latest.xcodeproj/project.pbxproj
+++ b/Latest.xcodeproj/project.pbxproj
@@ -80,6 +80,7 @@
 		50FEB87D2B1BE630006FB75D /* OSVersionTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50FEB87C2B1BE630006FB75D /* OSVersionTest.swift */; };
 		50FEB87F2B1BE67F006FB75D /* VersionSanitizationTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50FEB87E2B1BE67E006FB75D /* VersionSanitizationTest.swift */; };
 		50FEB8812B1D2402006FB75D /* ExcludedAppIdentifiers.plist in Resources */ = {isa = PBXBuildFile; fileRef = 50FEB8802B1D2402006FB75D /* ExcludedAppIdentifiers.plist */; };
+		50FFAA022D7A454000ABCDEF /* SparkleFeedURLTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50FFAA012D7A454000ABCDEF /* SparkleFeedURLTest.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -333,6 +334,7 @@
 		50FEB87C2B1BE630006FB75D /* OSVersionTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSVersionTest.swift; sourceTree = "<group>"; };
 		50FEB87E2B1BE67E006FB75D /* VersionSanitizationTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VersionSanitizationTest.swift; sourceTree = "<group>"; };
 		50FEB8802B1D2402006FB75D /* ExcludedAppIdentifiers.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = ExcludedAppIdentifiers.plist; sourceTree = "<group>"; };
+		50FFAA012D7A454000ABCDEF /* SparkleFeedURLTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SparkleFeedURLTest.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -644,6 +646,7 @@
 				50FEB87C2B1BE630006FB75D /* OSVersionTest.swift */,
 				50C81D731FBADC9100324C2E /* VersionTest.swift */,
 				50E4EB082B17DFCE00A70A7D /* VersionParserTest.swift */,
+				50FFAA012D7A454000ABCDEF /* SparkleFeedURLTest.swift */,
 				50FEB87E2B1BE67E006FB75D /* VersionSanitizationTest.swift */,
 			);
 			path = Tests;
@@ -999,6 +1002,7 @@
 				50FEB87D2B1BE630006FB75D /* OSVersionTest.swift in Sources */,
 				50FEB87F2B1BE67F006FB75D /* VersionSanitizationTest.swift in Sources */,
 				50E4EB092B17DFCE00A70A7D /* VersionParserTest.swift in Sources */,
+				50FFAA022D7A454000ABCDEF /* SparkleFeedURLTest.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Latest/Model/Sparkle/Sparkle.swift
+++ b/Latest/Model/Sparkle/Sparkle.swift
@@ -17,7 +17,7 @@ struct Sparke {
 		}
 
 		if let urlString = information["SUFeedURL"] as? String, let feedURL = URL(string: urlString.unquoted)  {
-			return feedURL
+			return Self.adjustedFeedURL(feedURL, bundleIdentifier: identifier, executableArchitectures: bundle.executableArchitectures)
 		} else { // Maybe the app is built using DevMate
 			// Check for the DevMate framework
 			let frameworksURL = URL(fileURLWithPath: bundle.bundlePath, isDirectory: true).appendingPathComponent("Contents").appendingPathComponent("Frameworks")
@@ -39,6 +39,61 @@ struct Sparke {
 		}
 	}
 	
+	static func adjustedFeedURL(_ feedURL: URL, bundleIdentifier: String, executableArchitectures: [NSNumber]?) -> URL {
+		guard Self.usesWiresharkArchitectureSpecificFeed(feedURL, bundleIdentifier: bundleIdentifier),
+			  let architecture = Self.architecturePathComponent(from: executableArchitectures),
+			  var components = URLComponents(url: feedURL, resolvingAgainstBaseURL: false) else {
+			return feedURL
+		}
+
+		var pathComponents = components.path.split(separator: "/").map(String.init)
+		guard pathComponents.count >= 6 else {
+			return feedURL
+		}
+
+		pathComponents[5] = architecture
+		components.path = "/\(pathComponents.joined(separator: "/"))"
+
+		return components.url ?? feedURL
+	}
+
+	private static func usesWiresharkArchitectureSpecificFeed(_ feedURL: URL, bundleIdentifier: String) -> Bool {
+		guard ["org.wireshark.Wireshark", "org.wireshark.Stratoshark"].contains(bundleIdentifier),
+			  ["wireshark.org", "www.wireshark.org"].contains(feedURL.host ?? "") else {
+			return false
+		}
+
+		let pathComponents = feedURL.path.split(separator: "/").map(String.init)
+		guard pathComponents.count >= 8 else {
+			return false
+		}
+
+		return pathComponents[0] == "update"
+			&& pathComponents[1] == "0"
+			&& pathComponents[4] == "macOS"
+	}
+
+	private static func architecturePathComponent(from executableArchitectures: [NSNumber]?) -> String? {
+		guard let executableArchitectures else {
+			return nil
+		}
+
+		if #available(macOS 11.0, *),
+		   executableArchitectures.contains(where: { $0.intValue == NSBundleExecutableArchitectureARM64 }) {
+			return "arm64"
+		}
+
+		if executableArchitectures.contains(where: { $0.intValue == NSBundleExecutableArchitectureX86_64 }) {
+			return "x86-64"
+		}
+
+		if executableArchitectures.contains(where: { $0.intValue == NSBundleExecutableArchitectureI386 }) {
+			return "x86"
+		}
+
+		return nil
+	}
+
 }
 
 fileprivate extension String {

--- a/Latest/Model/Update Checker Extensions/Sparkle/SparkleCheckerOperation.swift
+++ b/Latest/Model/Update Checker Extensions/Sparkle/SparkleCheckerOperation.swift
@@ -62,7 +62,7 @@ class SparkleUpdateCheckerOperation: StatefulOperation, UpdateCheckerOperation, 
 	
 	override func execute() {
 		// Gather app and app bundle
-		guard let bundle = Bundle(identifier: self.app.bundleIdentifier) else {
+		guard let bundle = Bundle(url: self.app.fileURL) ?? Bundle(identifier: self.app.bundleIdentifier) else {
 			self.finish(with: LatestError.updateInfoUnavailable)
 			return
 		}

--- a/Latest/Model/Updater/SparkleUpdateOperation.swift
+++ b/Latest/Model/Updater/SparkleUpdateOperation.swift
@@ -47,7 +47,7 @@ class SparkleUpdateOperation: UpdateOperation, @unchecked Sendable {
 		super.execute()
 		
 		// Gather app and app bundle
-		guard let bundle = Bundle(identifier: self.bundleIdentifier) else {
+		guard let bundle = Bundle(url: self.appIdentifier) ?? Bundle(identifier: self.bundleIdentifier) else {
 			self.finish(with: LatestError.updateInfoUnavailable)
 			return
 		}

--- a/Tests/SparkleFeedURLTest.swift
+++ b/Tests/SparkleFeedURLTest.swift
@@ -1,0 +1,46 @@
+//
+//  SparkleFeedURLTest.swift
+//  Latest Tests
+//
+//  Created for regression coverage.
+//
+
+import XCTest
+@testable import Latest
+
+final class SparkleFeedURLTest: XCTestCase {
+	
+	func testWiresharkFeedURLUsesArmArchitecture() {
+		let originalURL = URL(string: "https://www.wireshark.org/update/0/Wireshark/4.4.5/macOS/x86-64/en-US/stable.xml")!
+		let adjustedURL = Sparke.adjustedFeedURL(
+			originalURL,
+			bundleIdentifier: "org.wireshark.Wireshark",
+			executableArchitectures: [NSNumber(value: NSBundleExecutableArchitectureARM64)]
+		)
+		
+		XCTAssertEqual(adjustedURL.absoluteString, "https://www.wireshark.org/update/0/Wireshark/4.4.5/macOS/arm64/en-US/stable.xml")
+	}
+	
+	func testWiresharkFeedURLKeepsIntelArchitecture() {
+		let originalURL = URL(string: "https://www.wireshark.org/update/0/Wireshark/4.4.5/macOS/x86-64/en-US/stable.xml")!
+		let adjustedURL = Sparke.adjustedFeedURL(
+			originalURL,
+			bundleIdentifier: "org.wireshark.Wireshark",
+			executableArchitectures: [NSNumber(value: NSBundleExecutableArchitectureX86_64)]
+		)
+		
+		XCTAssertEqual(adjustedURL, originalURL)
+	}
+	
+	func testNonWiresharkFeedURLIsUnchanged() {
+		let originalURL = URL(string: "https://example.com/appcast.xml")!
+		let adjustedURL = Sparke.adjustedFeedURL(
+			originalURL,
+			bundleIdentifier: "com.example.App",
+			executableArchitectures: [NSNumber(value: NSBundleExecutableArchitectureARM64)]
+		)
+		
+		XCTAssertEqual(adjustedURL, originalURL)
+	}
+	
+}


### PR DESCRIPTION
## Summary

This fixes Wireshark/Stratoshark Sparkle updates resolving the wrong architecture-specific feed on Apple Silicon, which could lead to an ARM install being updated to the Intel build.

Closes #454.

## Root cause

Latest currently reads `SUFeedURL` directly from the target app bundle and treats it as authoritative.

For Wireshark and Stratoshark, the bundled macOS plist ships a static `SUFeedURL` that points to the `x86-64` appcast path. Their own updater code then rewrites that URL at runtime based on the actual build architecture (`x86-64` vs `arm64`).

That means external Sparkle consumers like Latest can end up using the Intel feed for an Apple Silicon install even though the installed bundle itself is ARM.

There was also a secondary precision issue in our Sparkle path: we resolved bundles by bundle identifier during check/install instead of preferring the exact on-disk bundle URL selected by the user.

## Changes

- detect Wireshark/Stratoshark architecture-specific feed URLs and rewrite the feed path to match the installed bundle's executable architecture
- prefer `Bundle(url:)` over `Bundle(identifier:)` when creating Sparkle updaters for both checking and installing
- add regression coverage for the Wireshark ARM feed rewrite path

## Verification

- `xcodebuild build -project 'Latest.xcodeproj' -scheme 'Latest' -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=''`

I also added a focused XCTest for the feed rewrite logic. I could not execute the test target successfully in this local environment because `Latest Tests` failed to resolve the private framework module dependencies `CommerceKit` and `StoreFoundation`, but the app build itself succeeds.

## Upstream

I opened an upstream Wireshark issue about the bundled Sparkle metadata always shipping an `x86-64` `SUFeedURL`:
- https://gitlab.com/wireshark/wireshark/-/work_items/21096
