### PR TITLE
Add Homebrew-based update support for limited apps

### DIFF
--- a/.github/workflows/macos-release.yml
+++ b/.github/workflows/macos-release.yml
@@ -1,0 +1,202 @@
+name: Build macOS Release Packages
+
+on:
+  push:
+    branches:
+      - "**"
+    tags:
+      - "**"
+
+permissions:
+  contents: write
+  pull-requests: read
+
+concurrency:
+  group: macos-release-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build ${{ matrix.label }} package
+    runs-on: macos-13
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: arm64
+            label: apple-silicon
+          - arch: x86_64
+            label: intel
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Resolve package dependencies
+        run: |
+          set -euo pipefail
+          xcodebuild -resolvePackageDependencies \
+            -project Latest.xcodeproj \
+            -scheme Latest
+
+      - name: Build app
+        env:
+          ARCH: ${{ matrix.arch }}
+        run: |
+          set -euo pipefail
+          DERIVED_DATA="${RUNNER_TEMP}/DerivedData-${ARCH}"
+
+          xcodebuild build \
+            -project Latest.xcodeproj \
+            -scheme Latest \
+            -configuration Release \
+            -destination "generic/platform=macOS" \
+            -derivedDataPath "${DERIVED_DATA}" \
+            ARCHS="${ARCH}" \
+            ONLY_ACTIVE_ARCH=NO \
+            CODE_SIGNING_ALLOWED=NO \
+            CODE_SIGN_IDENTITY=""
+
+          APP_PATH="${DERIVED_DATA}/Build/Products/Release/Latest.app"
+          if [[ ! -d "${APP_PATH}" ]]; then
+            echo "Expected app was not built at ${APP_PATH}" >&2
+            exit 1
+          fi
+
+          echo "APP_PATH=${APP_PATH}" >> "${GITHUB_ENV}"
+
+      - name: Build installer package
+        env:
+          ARCH: ${{ matrix.arch }}
+          LABEL: ${{ matrix.label }}
+        run: |
+          set -euo pipefail
+          VERSION="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "${APP_PATH}/Contents/Info.plist")"
+          BUILD="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleVersion' "${APP_PATH}/Contents/Info.plist")"
+          SHORT_SHA="${GITHUB_SHA::7}"
+          PACKAGE_VERSION="${VERSION}.${BUILD}"
+          ASSET_DIR="${RUNNER_TEMP}/release-assets"
+          PACKAGE_ARCH="${ARCH//_/-}"
+          PKG_PATH="${ASSET_DIR}/Latest-${VERSION}-${SHORT_SHA}-${LABEL}.pkg"
+
+          mkdir -p "${ASSET_DIR}"
+
+          pkgbuild \
+            --component "${APP_PATH}" \
+            --install-location "/Applications" \
+            --identifier "com.max-langer.Latest.${PACKAGE_ARCH}" \
+            --version "${PACKAGE_VERSION}" \
+            "${PKG_PATH}"
+
+          lipo -archs "${APP_PATH}/Contents/MacOS/Latest"
+          pkgutil --check-signature "${PKG_PATH}" || true
+
+          echo "ASSET_DIR=${ASSET_DIR}" >> "${GITHUB_ENV}"
+          echo "PKG_PATH=${PKG_PATH}" >> "${GITHUB_ENV}"
+
+      - name: Upload package artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: Latest-${{ matrix.label }}-pkg
+          path: ${{ env.PKG_PATH }}
+          if-no-files-found: error
+
+  release:
+    name: Publish GitHub release
+    runs-on: ubuntu-latest
+    needs: build
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Download packages
+        uses: actions/download-artifact@v4
+        with:
+          pattern: Latest-*-pkg
+          path: release-assets
+          merge-multiple: true
+
+      - name: Generate release notes
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
+            RELEASE_TAG="${GITHUB_REF_NAME}"
+            PREVIOUS_TAG="$(git describe --tags --abbrev=0 "${GITHUB_REF_NAME}^" 2>/dev/null || true)"
+            if [[ -n "${PREVIOUS_TAG}" ]]; then
+              RANGE="${PREVIOUS_TAG}..${GITHUB_REF_NAME}"
+            else
+              RANGE="${GITHUB_REF_NAME}"
+            fi
+            TITLE="Latest ${GITHUB_REF_NAME}"
+          else
+            SHORT_SHA="${GITHUB_SHA::7}"
+            RELEASE_TAG="build-${SHORT_SHA}"
+            RANGE="${GITHUB_SHA}^..${GITHUB_SHA}"
+            TITLE="Latest commit ${SHORT_SHA}"
+          fi
+
+          {
+            echo "## Changes"
+            echo
+            PR_JSON="$(gh pr list --state merged --search "${GITHUB_SHA}" --json number,title,url,mergedAt --limit 10 2>/dev/null || true)"
+            if [[ "${PR_JSON}" != "[]" && -n "${PR_JSON}" ]]; then
+              echo "${PR_JSON}" | jq -r '.[] | "- #\(.number) \(.title) (\(.url))"'
+            else
+              git log --no-merges --pretty=format:'- %s (%h)' "${RANGE}" || git log --no-merges -1 --pretty=format:'- %s (%h)' "${GITHUB_SHA}"
+              echo
+            fi
+            echo
+            echo "## Packages"
+            echo
+            echo "- Apple silicon: arm64 installer package"
+            echo "- Intel: x86_64 installer package"
+          } > RELEASE_NOTES.md
+
+          echo "RELEASE_TAG=${RELEASE_TAG}" >> "${GITHUB_ENV}"
+          echo "RELEASE_TITLE=${TITLE}" >> "${GITHUB_ENV}"
+
+      - name: Create or update release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          if gh release view "${RELEASE_TAG}" >/dev/null 2>&1; then
+            if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
+              gh release edit "${RELEASE_TAG}" \
+                --title "${RELEASE_TITLE}" \
+                --notes-file RELEASE_NOTES.md \
+                --prerelease=false \
+                --latest
+            else
+              gh release edit "${RELEASE_TAG}" \
+                --title "${RELEASE_TITLE}" \
+                --notes-file RELEASE_NOTES.md \
+                --prerelease
+            fi
+          else
+            if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
+              gh release create "${RELEASE_TAG}" \
+                --target "${GITHUB_SHA}" \
+                --title "${RELEASE_TITLE}" \
+                --notes-file RELEASE_NOTES.md \
+                --latest
+            else
+              gh release create "${RELEASE_TAG}" \
+                --target "${GITHUB_SHA}" \
+                --title "${RELEASE_TITLE}" \
+                --notes-file RELEASE_NOTES.md \
+                --prerelease \
+                --latest=false
+            fi
+          fi
+
+          gh release upload "${RELEASE_TAG}" release-assets/*.pkg --clobber

--- a/Latest.xcodeproj/project.pbxproj
+++ b/Latest.xcodeproj/project.pbxproj
@@ -77,6 +77,7 @@
 		50DAEF4421047FA900B32E8A /* UpdateItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50DAEF4321047FA900B32E8A /* UpdateItemView.swift */; };
 		50E4EB072B17DACB00A70A7D /* VersionParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50E4EB062B17DACB00A70A7D /* VersionParser.swift */; };
 		50E4EB092B17DFCE00A70A7D /* VersionParserTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50E4EB082B17DFCE00A70A7D /* VersionParserTest.swift */; };
+		50F1A0012E8346D200BEE001 /* HomebrewUpdateOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F1A0002E8346D200BEE001 /* HomebrewUpdateOperation.swift */; };
 		50FEB87D2B1BE630006FB75D /* OSVersionTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50FEB87C2B1BE630006FB75D /* OSVersionTest.swift */; };
 		50FEB87F2B1BE67F006FB75D /* VersionSanitizationTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50FEB87E2B1BE67E006FB75D /* VersionSanitizationTest.swift */; };
 		50FEB8812B1D2402006FB75D /* ExcludedAppIdentifiers.plist in Resources */ = {isa = PBXBuildFile; fileRef = 50FEB8802B1D2402006FB75D /* ExcludedAppIdentifiers.plist */; };
@@ -306,6 +307,7 @@
 		50E7ED4228611864006EF45F /* ms */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ms; path = ms.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		50E7ED4328611869006EF45F /* ms */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = ms; path = ms.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
 		50E7ED442861186D006EF45F /* ms */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ms; path = ms.lproj/Localizable.strings; sourceTree = "<group>"; };
+		50F1A0002E8346D200BEE001 /* HomebrewUpdateOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomebrewUpdateOperation.swift; sourceTree = "<group>"; };
 		50F542E022D9C41C004B3F8D /* CKDownloadQueueObserver.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CKDownloadQueueObserver.h; sourceTree = "<group>"; };
 		50F542E122D9C41C004B3F8D /* CKDownloadDirectory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CKDownloadDirectory.h; sourceTree = "<group>"; };
 		50F542E222D9C41C004B3F8D /* CKSoftwareMap.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CKSoftwareMap.h; sourceTree = "<group>"; };
@@ -416,6 +418,7 @@
 			children = (
 				5039DE8422CA396F0088B39B /* UpdateQueue.swift */,
 				5039DE8622CA39C60088B39B /* UpdateOperation.swift */,
+				50F1A0002E8346D200BEE001 /* HomebrewUpdateOperation.swift */,
 				5087CD2C22F6E06B0013354C /* SparkleUpdateOperation.swift */,
 				5039DE8C22CAA2790088B39B /* MacAppStoreUpdateOperation.swift */,
 			);
@@ -967,6 +970,7 @@
 				502929F62120624700F00D1C /* ReleaseNotesLoadingViewController.swift in Sources */,
 				5039DE8722CA39C60088B39B /* UpdateOperation.swift in Sources */,
 				506A8F6722EC14CC00C755AF /* LatestError.swift in Sources */,
+				50F1A0012E8346D200BEE001 /* HomebrewUpdateOperation.swift in Sources */,
 				509512281FF3631D003D2D7F /* UpdateCheckCoordinator.swift in Sources */,
 				504FB4AC2B76CA77009C73E9 /* AppLocationViewController.swift in Sources */,
 				5073753F278998A300F371D8 /* AppLibrary.swift in Sources */,

--- a/Latest/Interface/Base.lproj/Main.storyboard
+++ b/Latest/Interface/Base.lproj/Main.storyboard
@@ -1357,7 +1357,7 @@
                                                     <rect key="frame" x="18" y="0.0" width="330" height="56"/>
                                                     <textFieldCell key="cell" id="rG3-x9-kec">
                                                         <font key="font" metaFont="smallSystem"/>
-                                                        <string key="title">List apps with limited support. Update information may be outdated or inaccurate, and updates cannot be performed directly in Latest.
+                                                        <string key="title">List apps that can be updated via Homebrew. Latest can show their update information and, if Homebrew is installed, run brew commands to update them.
 </string>
                                                         <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
                                                         <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>

--- a/Latest/Interface/Main Window/Views/UpdateButton.swift
+++ b/Latest/Interface/Main Window/Views/UpdateButton.swift
@@ -123,8 +123,11 @@ class UpdateButton: NSButton {
 		
 	/// Updates the UI state with the given progress definition.
 	private func updateInterface(with state: UpdateOperation.ProgressState) {
+		let customStatus = self.app.map { UpdateQueue.shared.statusDescription(for: $0.identifier) }
+
 		switch state {
 		case .none:
+			self.toolTip = nil
 			if let app = self.app, self.showActionButton {
 				self.updateInterfaceVisibility(with: app.updateAvailable ? .update : .open)
 			} else {
@@ -133,11 +136,11 @@ class UpdateButton: NSButton {
 		
 		case .pending:
 			self.updateInterfaceVisibility(with: .indeterminate)
-			self.toolTip = NSLocalizedString("WaitingUpdateStatus", comment: "Update progress state of waiting to start an update")
+			self.toolTip = customStatus ?? NSLocalizedString("WaitingUpdateStatus", comment: "Update progress state of waiting to start an update")
 		
 		case .initializing:
 			self.updateInterfaceVisibility(with: .indeterminate)
-			self.toolTip = NSLocalizedString("InitializingUpdateStatus", comment: "Update progress state of initializing an update")
+			self.toolTip = customStatus ?? NSLocalizedString("InitializingUpdateStatus", comment: "Update progress state of initializing an update")
 		
 		case .downloading(let loadedSize, let totalSize):
 			self.updateInterfaceVisibility(with: .progress)
@@ -145,30 +148,35 @@ class UpdateButton: NSButton {
 			// Downloading goes to 75% of the progress
 			self.contentCell.updateProgress = (Double(loadedSize) / Double(totalSize)) * 0.75
 			
-			let byteFormatter = ByteCountFormatter()
-			byteFormatter.countStyle = .file
-			
-			let formatString = NSLocalizedString("DownloadingUpdateStatus", comment: "Update progress state of downloading an update. The first %@ stands for the already downloaded bytes, the second one for the total amount of bytes. One expected output would be 'Downloading 3 MB of 21 MB'")
-			self.toolTip = String.localizedStringWithFormat(formatString, byteFormatter.string(fromByteCount: loadedSize), byteFormatter.string(fromByteCount: totalSize))
+			if let customStatus = customStatus {
+				self.toolTip = customStatus
+			} else {
+				let byteFormatter = ByteCountFormatter()
+				byteFormatter.countStyle = .file
+				
+				let formatString = NSLocalizedString("DownloadingUpdateStatus", comment: "Update progress state of downloading an update. The first %@ stands for the already downloaded bytes, the second one for the total amount of bytes. One expected output would be 'Downloading 3 MB of 21 MB'")
+				self.toolTip = String.localizedStringWithFormat(formatString, byteFormatter.string(fromByteCount: loadedSize), byteFormatter.string(fromByteCount: totalSize))
+			}
 		
 		case .extracting(let progress):
 			self.updateInterfaceVisibility(with: .progress)
 			
 			// Extracting goes to 95%
 			self.contentCell.updateProgress = 0.75 + (progress * 0.25)
-			self.toolTip = NSLocalizedString("ExtractingUpdateStatus", comment: "Update progress state of extracting the downloaded update")
+			self.toolTip = customStatus ?? NSLocalizedString("ExtractingUpdateStatus", comment: "Update progress state of extracting the downloaded update")
 		
 		case .installing:
 			self.updateInterfaceVisibility(with: .indeterminate)
-			self.toolTip = NSLocalizedString("InstallingUpdateStatus", comment: "Update progress state of installing an update")
+			self.toolTip = customStatus ?? NSLocalizedString("InstallingUpdateStatus", comment: "Update progress state of installing an update")
 		
 		case .error(let error):
 			self.updateInterfaceVisibility(with: self.showActionButton ? .error : .none)
+			self.toolTip = nil
 			self.error = error
 		
 		case .cancelling:
 			self.updateInterfaceVisibility(with: .indeterminate)
-			self.toolTip = NSLocalizedString("CancellingUpdateStatus", comment: "Update progress state of cancelling an update")
+			self.toolTip = customStatus ?? NSLocalizedString("CancellingUpdateStatus", comment: "Update progress state of cancelling an update")
 		}
 	}
 	
@@ -268,12 +276,28 @@ private extension UpdateButton {
 		let message = NSLocalizedString("UpdateErrorAlertTitle", comment: "Title of alert stating that an error occurred during an app update. The placeholder %@ will be replaced with the name of the app.")
 		alert.messageText = String.localizedStringWithFormat(message, self.app!.name)
 		
-		alert.informativeText = error.localizedDescription
+		alert.informativeText = self.informativeText(for: error)
 		
 		alert.addButton(withTitle: NSLocalizedString("RetryAction", comment: "Button to retry an update in an error dialogue"))
 		alert.addButton(withTitle: NSLocalizedString("CancelAction", comment: "Cancel button in an update dialogue"))
 		
 		return alert
+	}
+
+	private func informativeText(for error: Error) -> String {
+		var parts = [error.localizedDescription]
+
+		if let localizedError = error as? LocalizedError {
+			if let failureReason = localizedError.failureReason, failureReason != error.localizedDescription {
+				parts.append(failureReason)
+			}
+
+			if let recoverySuggestion = localizedError.recoverySuggestion {
+				parts.append(recoverySuggestion)
+			}
+		}
+
+		return parts.joined(separator: "\n\n")
 	}
 	
 }

--- a/Latest/Interface/en.lproj/Main.strings
+++ b/Latest/Interface/en.lproj/Main.strings
@@ -376,5 +376,5 @@
 /* Class = "NSButtonCell"; title = "Report Issue…"; ObjectID = "pNJ-Hl-Qxz"; */
 "pNJ-Hl-Qxz.title" = "Report Issue…";
 
-/* Class = "NSTextFieldCell"; title = "List apps with limited support. Update information may be outdated or inaccurate, and updates cannot be performed directly in Latest.\n"; ObjectID = "rG3-x9-kec"; */
-"rG3-x9-kec.title" = "List apps with limited support. Update information may be outdated or inaccurate, and updates cannot be performed directly in Latest.\n";
+/* Class = "NSTextFieldCell"; title = "List apps that can be updated via Homebrew. Latest can show their update information and, if Homebrew is installed, run brew commands to update them.\n"; ObjectID = "rG3-x9-kec"; */
+"rG3-x9-kec.title" = "List apps that can be updated via Homebrew. Latest can show their update information and, if Homebrew is installed, run brew commands to update them.\n";

--- a/Latest/Interface/zh-Hans.lproj/Main.strings
+++ b/Latest/Interface/zh-Hans.lproj/Main.strings
@@ -340,5 +340,5 @@
 "NvM-TY-Zhn.title" = "<dnl>";
 "Uax-et-NIt.title" = "打开";
 "Mdn-MF-57Q.title" = "显示没有可用更新信息的应用。";
-"rG3-x9-kec.title" = "列出有限支持的应用。更新信息可能过时或不准确，且无法在Latest中直接执行更新。\n";
+"rG3-x9-kec.title" = "列出可通过 Homebrew 更新的应用。Latest 可以显示其更新信息，并在已安装 Homebrew 时调用 brew 命令执行更新。\n";
 "DfQ-ss-Qv2.title" = "设置";

--- a/Latest/Model/Directory/BundleCollector.swift
+++ b/Latest/Model/Directory/BundleCollector.swift
@@ -49,11 +49,11 @@ enum BundleCollector {
 		
 	/// Returns a bundle representation for the app at the given url, without Spotlight Metadata.
 	static private func bundle(forAppAt url: URL) -> App.Bundle? {
-		guard let appBundle = Bundle(url: url),
-			  let buildNumber = appBundle.uncachedBundleVersion,
-			  let identifier = appBundle.bundleIdentifier,
-			  let versionNumber = appBundle.versionNumber,
-			  let appName = appBundle.bundleName else {
+		guard let info = AppBundleInfo(url: url),
+			  let buildNumber = info.buildNumber,
+			  let identifier = info.bundleIdentifier,
+			  let versionNumber = info.versionNumber,
+			  let appName = info.name else {
 			return nil
 		}
 		
@@ -79,26 +79,54 @@ enum BundleCollector {
 
 }
 
+fileprivate struct AppBundleInfo {
+	
+	let dictionary: [String: Any]
+	let fallbackBundle: Bundle?
+	
+	init?(url: URL) {
+		fallbackBundle = Bundle(url: url)
+		
+		let infoURL = url.appendingPathComponent("Contents").appendingPathComponent("Info.plist")
+		if let data = try? Data(contentsOf: infoURL),
+		   let propertyList = try? PropertyListSerialization.propertyList(from: data, format: nil),
+		   let dictionary = propertyList as? [String: Any] {
+			self.dictionary = dictionary
+		} else if let fallbackDictionary = fallbackBundle?.uncachedInfoDictionary {
+			self.dictionary = fallbackDictionary
+		} else {
+			return nil
+		}
+	}
+	
+	var buildNumber: String? {
+		return dictionary["CFBundleVersion"] as? String
+	}
+	
+	var bundleIdentifier: String? {
+		return (dictionary["CFBundleIdentifier"] as? String) ?? fallbackBundle?.bundleIdentifier
+	}
+	
+	var name: String? {
+		return dictionary["CFBundleName"] as? String
+	}
+	
+	var versionNumber: String? {
+		return dictionary["CFBundleShortVersionString"] as? String
+	}
+	
+}
+
 fileprivate extension Bundle {
 	
-	/// Returns the bundle version which is guaranteed to be current.
-	var uncachedBundleVersion: String? {
+	/// Returns the info dictionary after asking CoreFoundation to drop cached bundle state.
+	var uncachedInfoDictionary: [String: Any]? {
 		let bundleRef = CFBundleCreate(.none, self.bundleURL as CFURL)
 		
 		// (NS)Bundle has a cache for (all?) properties, presumably to reduce disk access. Therefore, after updating an app, the old bundle version may be
 		// returned. Flushing the cache (private method) resolves this.
 		_CFBundleFlushBundleCaches(bundleRef)
 		
-		return infoDictionary?["CFBundleVersion"] as? String
-	}
-	
-	/// Returns the bundle name when working without Spotlight.
-	var bundleName: String? {
-		return infoDictionary?["CFBundleName"] as? String
-	}
-	
-	/// Returns the short version string when working without Spotlight.
-	var versionNumber: String? {
-		return infoDictionary?["CFBundleShortVersionString"] as? String
+		return infoDictionary
 	}
 }

--- a/Latest/Model/Source.swift
+++ b/Latest/Model/Source.swift
@@ -63,7 +63,7 @@ extension App.Source {
 		/// The source is fully supported, including in-app updates.
 		case full
 		
-		/// There is some update information available, but it may be incomplete. In-app updates do not work.
+		/// Update information is available and Latest can update the app with limited integration, such as via Homebrew.
 		case limited
 		
 		/// The source is unknown and no update information is available.
@@ -87,22 +87,33 @@ extension App.Source {
 // MARK: Accessors
 
 extension App.Source.SupportState {
+	private static let limitedColor = NSColor(red: 249.0 / 255.0, green: 208.0 / 255.0, blue: 148.0 / 255.0, alpha: 1.0)
+
 	/// Returns an image using the system status indicator (colored dot) for the given status.
 	var statusImage: NSImage {
-		let name = switch self {
-		case .full: NSImage.statusAvailableName
-		case .limited: NSImage.statusPartiallyAvailableName
-		case .none: NSImage.statusUnavailableName
+		switch self {
+		case .limited:
+			let baseImage = NSImage(named: NSImage.statusPartiallyAvailableName)!
+			let image = NSImage(size: baseImage.size, flipped: false) { rect in
+				baseImage.draw(in: rect)
+				Self.limitedColor.setFill()
+				rect.fill(using: .sourceAtop)
+				return true
+			}
+			image.isTemplate = false
+			return image
+		case .full, .none:
+			let name = self == .full ? NSImage.statusAvailableName : NSImage.statusUnavailableName
+			
+			return NSImage(named: name)!
 		}
-		
-		return NSImage(named: name)!
 	}
 	
 	/// Returns a label briefly describing the given status.
 	var label: String {
 		switch self {
 		case .full: NSLocalizedString("SupportedLabel", comment: "A label used for apps which are fully supported by Latest.")
-		case .limited: NSLocalizedString("LimitedSupportLabel", comment: "A label used for apps which are partially supported by Latest.")
+		case .limited: NSLocalizedString("LimitedSupportLabel", comment: "A label used for apps which are updated via Homebrew.")
 		case .none: NSLocalizedString("UnsupportedLabel", comment: "A label used for apps which are not supported by Latest.")
 		}
 	}
@@ -111,7 +122,7 @@ extension App.Source.SupportState {
 	var compactLabel: String {
 		switch self {
 		case .full: NSLocalizedString("SupportedCompactLabel", comment: "A compact label used for apps which are fully supported by Latest.")
-		case .limited: NSLocalizedString("LimitedSupportCompactLabel", comment: "A compact label used for apps which are partially supported by Latest.")
+		case .limited: NSLocalizedString("LimitedSupportCompactLabel", comment: "A compact label used for apps which are updated via Homebrew.")
 		case .none: NSLocalizedString("UnsupportedCompactLabel", comment: "A compact label used for apps which are not supported by Latest.")
 		}
 	}

--- a/Latest/Model/Update Checker Extensions/Homebrew/HomebrewCheckerOperation.swift
+++ b/Latest/Model/Update Checker Extensions/Homebrew/HomebrewCheckerOperation.swift
@@ -51,12 +51,22 @@ class HomebrewCheckerOperation: StatefulOperation, UpdateCheckerOperation, @unch
 			return
 		}
 		
-		repository.updateInfo(for: bundle) { bundle, version, minimumOSVersion in
+		repository.homebrewEntry(for: bundle) { bundle, entry in
 			defer { self.finish() }
-			guard let version else { return }
-			self.update = App.Update(app: bundle, remoteVersion: version, minimumOSVersion: minimumOSVersion, source: .homebrew, date: nil, releaseNotes: nil, updateAction: .external(label: bundle.name, block: { app in
-				app.open()
-			}))
+			guard let entry else { return }
+
+			let action: App.Update.Action
+			if HomebrewTool.isAvailable {
+				action = .builtIn(block: { app in
+					UpdateQueue.shared.addOperation(HomebrewUpdateOperation(bundleIdentifier: app.bundleIdentifier, appIdentifier: app.identifier, caskToken: entry.token))
+				})
+			} else {
+				action = .external(label: bundle.name, block: { app in
+					app.open()
+				})
+			}
+
+			self.update = App.Update(app: bundle, remoteVersion: entry.version, minimumOSVersion: entry.minimumOSVersion, source: .homebrew, date: nil, releaseNotes: nil, updateAction: action)
 		}
 	}
 	

--- a/Latest/Model/Update Repository/UpdateRepository+Entry.swift
+++ b/Latest/Model/Update Repository/UpdateRepository+Entry.swift
@@ -81,11 +81,9 @@ extension UpdateRepository {
 			bundleIdentifiers = Set(artifacts.identifiers)
 
 			// OS Version
-			if let osVersion = try container.decode(MinimumOS.self, forKey: .minimumOSVersion).macos?.version?.first {
-				minimumOSVersion = try OperatingSystemVersion(string: osVersion)
-			} else {
-				minimumOSVersion = nil
-			}
+            if let osVersion = try container.decode(MinimumOS.self, forKey: .minimumOSVersion).macos?.version?.first, !osVersion.isEmpty { minimumOSVersion = try OperatingSystemVersion(string: osVersion) } else {
+                minimumOSVersion = nil
+            }
 		}
 		
 		

--- a/Latest/Model/Update Repository/UpdateRepository.swift
+++ b/Latest/Model/Update Repository/UpdateRepository.swift
@@ -47,13 +47,15 @@ class UpdateRepository {
 	
 	/// Returns update information for the given bundle.
 	func updateInfo(for bundle: App.Bundle, handler: @escaping (_ bundle: App.Bundle, _ version: Version?, _ minimumOSVersion: OperatingSystemVersion?) -> Void) {
+		self.homebrewEntry(for: bundle) { bundle, entry in
+			handler(bundle, entry?.version, entry?.minimumOSVersion)
+		}
+	}
+
+	/// Returns the Homebrew repository entry for the given bundle, if available.
+	func homebrewEntry(for bundle: App.Bundle, handler: @escaping (_ bundle: App.Bundle, _ entry: Entry?) -> Void) {
 		let checkApp = {
-			guard let entry = self.entry(for: bundle) else {
-				handler(bundle, nil, nil)
-				return
-			}
-			
-			return handler(bundle, entry.version, entry.minimumOSVersion)
+			handler(bundle, self.entry(for: bundle))
 		}
 		
 		/// Entries are still being fetched, add the request to the queue.

--- a/Latest/Model/Updater/HomebrewUpdateOperation.swift
+++ b/Latest/Model/Updater/HomebrewUpdateOperation.swift
@@ -1,0 +1,227 @@
+//
+//  HomebrewUpdateOperation.swift
+//  Latest
+//
+//  Created by qetesh on 14.03.26.
+//
+
+import Foundation
+
+enum HomebrewTool {
+
+	static var isAvailable: Bool {
+		executableURL != nil
+	}
+
+	static let executableURL: URL? = {
+		let knownPaths = [
+            "/opt/homebrew/bin/brew",
+            "/usr/local/bin/brew"
+        ]
+        let fileManager = FileManager.default
+        for path in knownPaths {
+            if fileManager.isExecutableFile(atPath: path) {
+                return URL(fileURLWithPath: path)
+            }
+        }
+        return nil
+    }()
+}
+
+/// The operation updating Homebrew casks.
+class HomebrewUpdateOperation: UpdateOperation, @unchecked Sendable {
+    
+    private static let ansiEscapeRegex = try? NSRegularExpression(pattern: "\u{001B}\\[[0-9;]*[A-Za-z]")
+    
+    private let caskToken: String
+    
+    private var process: Process?
+    private var outputBuffer = ""
+    private var recentOutputLines = [String]()
+    private let outputQueue = DispatchQueue(label: "HomebrewUpdateOperation.output")
+    
+    init(bundleIdentifier: String, appIdentifier: App.Bundle.Identifier, caskToken: String) {
+        self.caskToken = caskToken
+        super.init(bundleIdentifier: bundleIdentifier, appIdentifier: appIdentifier)
+    }
+    
+    
+    // MARK: - Operation Overrides
+    
+    override func execute() {
+        super.execute()
+        
+        guard HomebrewTool.isAvailable else {
+            self.finishHomebrewUnavailable()
+            return
+        }
+        
+        self.startUpdate()
+    }
+    
+    override func cancel() {
+        super.cancel()
+        self.process?.terminate()
+    }
+    
+    override func finish() {
+        self.process = nil
+        super.finish()
+    }
+    
+    
+    // MARK: - Running Commands
+    
+    private func startUpdate() {
+        self.progressDescription = NSLocalizedString("HomebrewRunningUpdateStatus", comment: "Status text while running brew update.")
+        self.progressState = .downloading(loadedSize: 1, totalSize: 4)
+        self.run(arguments: ["update"]) { success in
+            guard success else { return }
+            self.startReinstall()
+        }
+    }
+    
+    private func startReinstall() {
+        let format = NSLocalizedString("HomebrewRunningReinstallStatus", comment: "Status text while running brew reinstall for a cask. The placeholder is the cask token.")
+        self.progressDescription = String.localizedStringWithFormat(format, self.caskToken)
+        self.progressState = .downloading(loadedSize: 2, totalSize: 4)
+        self.run(arguments: ["reinstall", "--cask", "--force", self.caskToken]) { success in
+            guard success else { return }
+            self.finish()
+        }
+    }
+    
+    private func run(arguments: [String], completion: @escaping (Bool) -> Void) {
+        guard let executableURL = HomebrewTool.executableURL else {
+            self.finishHomebrewUnavailable()
+            return
+        }
+        
+        let process = Process()
+        let pipe = Pipe()
+        
+        process.executableURL = executableURL
+        process.arguments = arguments
+        process.standardOutput = pipe
+        process.standardError = pipe
+        
+        let fileHandle = pipe.fileHandleForReading
+        fileHandle.readabilityHandler = { [weak self] handle in
+            let data = handle.availableData
+            guard !data.isEmpty else { return }
+            self?.consumeOutput(data, arguments: arguments)
+        }
+        
+        process.terminationHandler = { [weak self] process in
+            guard let self else { return }
+            fileHandle.readabilityHandler = nil
+            self.flushOutput(arguments: arguments)
+            
+            if self.isCancelled {
+                self.finish()
+                return
+            }
+            
+            guard process.terminationStatus == 0 else {
+                self.finish(with: self.homebrewFailureError(for: arguments))
+                return
+            }
+            
+            completion(true)
+        }
+        
+        do {
+            try process.run()
+            self.process = process
+        } catch {
+            self.finish(with: error)
+        }
+    }
+    
+    
+    // MARK: - Output Handling
+    
+    private func consumeOutput(_ data: Data, arguments: [String]) {
+        outputQueue.async {
+            guard let string = String(data: data, encoding: .utf8), !string.isEmpty else { return }
+            self.outputBuffer += string
+            
+            let lines = self.outputBuffer.components(separatedBy: .newlines)
+            self.outputBuffer = lines.last ?? ""
+            
+            for line in lines.dropLast() {
+                self.handleOutputLine(line, arguments: arguments)
+            }
+        }
+    }
+    
+    private func flushOutput(arguments: [String]) {
+        outputQueue.sync {
+            guard !self.outputBuffer.isEmpty else { return }
+            self.handleOutputLine(self.outputBuffer, arguments: arguments)
+            self.outputBuffer = ""
+		}
+	}
+
+	private func handleOutputLine(_ line: String, arguments: [String]) {
+		let cleanedLine = self.clean(line)
+		guard !cleanedLine.isEmpty else { return }
+
+		self.recentOutputLines.append(cleanedLine)
+		if self.recentOutputLines.count > 20 {
+			self.recentOutputLines.removeFirst(self.recentOutputLines.count - 20)
+		}
+
+		self.progressDescription = cleanedLine
+
+		if arguments.first == "update" {
+			self.progressState = .downloading(loadedSize: 1, totalSize: 4)
+			return
+		}
+
+		if cleanedLine.localizedCaseInsensitiveContains("Downloading") {
+			self.progressState = .downloading(loadedSize: 3, totalSize: 4)
+		} else if cleanedLine.hasPrefix("==> Reinstalling") {
+			self.progressState = .extracting(progress: 0.4)
+		} else if cleanedLine.hasPrefix("==> Installing")
+			|| cleanedLine.hasPrefix("==> Pouring")
+			|| cleanedLine.hasPrefix("==> Moving App")
+			|| cleanedLine.hasPrefix("==> Linking")
+			|| cleanedLine.hasPrefix("==> Artifact") {
+			self.progressState = .extracting(progress: 0.6)
+		} else if cleanedLine.hasPrefix("==> Cleaning")
+			|| cleanedLine.hasPrefix("==> Purging") {
+			self.progressState = .extracting(progress: 0.9)
+		} else {
+			self.progressState = .downloading(loadedSize: 2, totalSize: 4)
+		}
+	}
+
+	private func finishHomebrewUnavailable() {
+		let title = NSLocalizedString("HomebrewNotFoundError", comment: "Title of error shown when Homebrew is not installed.")
+		let description = NSLocalizedString("HomebrewNotFoundErrorDescription", comment: "Description of error shown when Homebrew is not installed, suggesting the user install it.")
+		self.finish(with: LatestError.custom(title: title, description: description))
+	}
+
+	private func homebrewFailureError(for arguments: [String]) -> LatestError {
+		let description = self.outputQueue.sync {
+			self.recentOutputLines.joined(separator: "\n")
+		}
+		let fallbackFormat = NSLocalizedString("HomebrewCommandFailedError", comment: "Error message shown when a Homebrew command failed. The placeholder is the command arguments.")
+		let errorDescription = description.isEmpty ? String.localizedStringWithFormat(fallbackFormat, arguments.joined(separator: " ")) : description
+		let title = NSLocalizedString("HomebrewUpdateFailedError", comment: "Title of error shown when a Homebrew update failed.")
+		return LatestError.custom(title: title, description: errorDescription)
+	}
+
+	private func clean(_ line: String) -> String {
+		let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+		guard !trimmed.isEmpty else { return "" }
+
+		guard let regex = Self.ansiEscapeRegex else {
+			return trimmed
+		}
+
+		let range = NSRange(location: 0, length: trimmed.utf16.count)
+		return regex.stringByReplacingMatches(in: trimmed, options: [], range: range, withTemplate: "")
+	}
+}

--- a/Latest/Model/Updater/UpdateOperation.swift
+++ b/Latest/Model/Updater/UpdateOperation.swift
@@ -43,19 +43,69 @@ class UpdateOperation: StatefulOperation, @unchecked Sendable {
 	
 	/// The identifier of the updated app.
 	let appIdentifier: App.Bundle.Identifier
+
+	/// Guards access to progress state shared between background work and the UI.
+	private let progressLock = NSLock()
+
+	/// Private storage for the current progress handler.
+	private var _progressHandler: UpdateQueue.ProgressHandler?
+
+	/// Private storage for the current progress description.
+	private var _progressDescription: String?
+
+	/// Private storage for the current progress state.
+	private var _progressState: UpdateOperation.ProgressState = .pending
 	
 	/// The handler forwarding the current progress state.
 	var progressHandler: UpdateQueue.ProgressHandler? {
-		didSet {
+		get {
+			return self.progressLock.withCriticalScope {
+				self._progressHandler
+			}
+		}
+		set {
+			let handler = self.progressLock.withCriticalScope { () -> UpdateQueue.ProgressHandler? in
+				self._progressHandler = newValue
+				return self._progressHandler
+			}
+
 			// Notify immediately
-			self.progressHandler?(self.appIdentifier)
+			handler?(self.appIdentifier)
+		}
+	}
+
+	/// The text describing the current progress state.
+	var progressDescription: String? {
+		get {
+			return self.progressLock.withCriticalScope {
+				self._progressDescription
+			}
+		}
+		set {
+			let handler = self.progressLock.withCriticalScope { () -> UpdateQueue.ProgressHandler? in
+				guard self._progressDescription != newValue else { return nil }
+				self._progressDescription = newValue
+				return self._progressHandler
+			}
+
+			handler?(self.appIdentifier)
 		}
 	}
 	
-		/// The current update state.
-	var progressState: UpdateOperation.ProgressState = .pending {
-		didSet {
-			self.progressHandler?(self.appIdentifier)
+	/// The current update state.
+	var progressState: UpdateOperation.ProgressState {
+		get {
+			return self.progressLock.withCriticalScope {
+				self._progressState
+			}
+		}
+		set {
+			let handler = self.progressLock.withCriticalScope { () -> UpdateQueue.ProgressHandler? in
+				self._progressState = newValue
+				return self._progressHandler
+			}
+
+			handler?(self.appIdentifier)
 		}
 	}
 
@@ -70,15 +120,18 @@ class UpdateOperation: StatefulOperation, @unchecked Sendable {
 	// MARK: - Operation sub-classing
 	
 	override func execute() {
+		self.progressDescription = nil
 		self.progressState = .initializing
 	}
 	
 	override func cancel() {
 		super.cancel()
+		self.progressDescription = nil
 		self.progressState = .cancelling
 	}
 		
 	override func finish() {
+		self.progressDescription = nil
 		if let error = self.error {
 			self.progressState = .error(error)
 		} else {

--- a/Latest/Model/Updater/UpdateQueue.swift
+++ b/Latest/Model/Updater/UpdateQueue.swift
@@ -42,6 +42,11 @@ class UpdateQueue: OperationQueue, @unchecked Sendable {
 	func state(for identifier: App.Bundle.Identifier) -> UpdateOperation.ProgressState {
 		return self.operation(for: identifier)?.progressState ?? .none
 	}
+
+	/// Returns the current status description for a given app.
+	func statusDescription(for identifier: App.Bundle.Identifier) -> String? {
+		return self.operation(for: identifier)?.progressDescription
+	}
 	
 	override func addOperation(_ op: Operation) {
 		// Abort if the operation is of an unknown type
@@ -52,6 +57,11 @@ class UpdateQueue: OperationQueue, @unchecked Sendable {
 		
 		// Abort if the app is already in the queue
 		if !self.contains(operation.appIdentifier) {
+			if let homebrewOperation = operation as? HomebrewUpdateOperation,
+			   let previousHomebrewOperation = self.operations.compactMap({ $0 as? HomebrewUpdateOperation }).last {
+				homebrewOperation.addDependency(previousHomebrewOperation)
+			}
+
 			super.addOperation(op)
 			
 			operation.progressHandler = { identifier in
@@ -69,35 +79,59 @@ class UpdateQueue: OperationQueue, @unchecked Sendable {
 	/// A mapping of observers associated with apps.
 	private var observers = [App.Bundle.Identifier : [NSObject: ObserverHandler]]()
 	
+	/// App identifiers that already have an observer update queued on the main thread.
+	private var pendingNotifications = Set<App.Bundle.Identifier>()
+	
+	/// Guards access to observer bookkeeping.
+	private let observerLock = NSLock()
+	
 	/// Adds the observer if it is not already registered.
 	func addObserver(_ observer: NSObject, to identifier: App.Bundle.Identifier, handler: @escaping ObserverHandler) {
-		var observers = self.observers[identifier] ?? [:]
-		
-		// Only add the observer, if it is not already installed.
-		guard observers[observer] == nil else {
-			return
+		let shouldRegister = self.observerLock.withCriticalScope { () -> Bool in
+			var observers = self.observers[identifier] ?? [:]
+			
+			// Only add the observer, if it is not already installed.
+			guard observers[observer] == nil else {
+				return false
+			}
+			
+			observers[observer] = handler
+			self.observers[identifier] = observers
+			return true
 		}
-		
-		observers[observer] = handler
+		guard shouldRegister else { return }
 		
 		// Call handler immediately to propagate initial state
 		handler(self.state(for: identifier))
-		
-		// Update observers
-		self.observers[identifier] = observers
 	}
 	
 	/// Removes the observer.
 	func removeObserver(_ observer: NSObject, for identifier: App.Bundle.Identifier) {
-		self.observers[identifier]?.removeValue(forKey: observer)
+		_ = self.observerLock.withCriticalScope {
+			self.observers[identifier]?.removeValue(forKey: observer)
+		}
 	}
 		
 	/// Notifies observers about state changes.
 	private func notifyObservers(for identifier: App.Bundle.Identifier) {
-		let state = self.state(for: identifier)
+		let shouldSchedule = self.observerLock.withCriticalScope { () -> Bool in
+			guard !self.pendingNotifications.contains(identifier) else {
+				return false
+			}
+			
+			self.pendingNotifications.insert(identifier)
+			return true
+		}
+		guard shouldSchedule else { return }
 		
 		DispatchQueue.main.async {
-			self.observers[identifier]?.forEach { (key: NSObject, handler: UpdateQueue.ObserverHandler) in
+			let state = self.state(for: identifier)
+			let handlers = self.observerLock.withCriticalScope { () -> [UpdateQueue.ObserverHandler] in
+				self.pendingNotifications.remove(identifier)
+				return Array((self.observers[identifier] ?? [:]).values)
+			}
+			
+			handlers.forEach { handler in
 				handler(state)
 			}
 		}

--- a/Latest/Resources/en.lproj/Localizable.strings
+++ b/Latest/Resources/en.lproj/Localizable.strings
@@ -68,7 +68,25 @@
 "InstallingUpdateStatus" = "Installing";
 
 /* Description for apps with limited support. */
-"LimitedSupportDescription" = "Update information is generally available but may sometimes be outdated or inaccurate. Updates cannot be performed directly here.";
+"LimitedSupportDescription" = "This app can be updated via Homebrew. Latest can run brew commands to perform the update when Homebrew is installed.";
+
+/* Title of error shown when a Homebrew update failed. */
+"HomebrewUpdateFailedError" = "Homebrew Update Failed";
+
+/* Error message shown when a Homebrew command failed. The placeholder is the command arguments. */
+"HomebrewCommandFailedError" = "brew %@ failed.";
+
+/* Status text while running brew update. */
+"HomebrewRunningUpdateStatus" = "Running brew update";
+
+/* Status text while running brew reinstall for a cask. The placeholder is the cask token. */
+"HomebrewRunningReinstallStatus" = "Running brew reinstall --cask --force %@";
+
+/* Title of error shown when Homebrew is not installed. */
+"HomebrewNotFoundError" = "Homebrew Not Found";
+
+/* Description of error shown when Homebrew is not installed, suggesting the user install it. */
+"HomebrewNotFoundErrorDescription" = "Install Homebrew to update cask apps from Latest.";
 
 /* Current Version String */
 "LocalVersionFormat" = "Your version: %@";
@@ -131,7 +149,7 @@
 "LimitedSupportCompactLabel" = "Limited";
 
 /* A label used for apps which are partially supported by Latest. */
-"LimitedSupportLabel" = "Limited support";
+"LimitedSupportLabel" = "Updated via Homebrew";
 
 /* A compact label used for apps which are fully supported by Latest. */
 "SupportedCompactLabel" = "Supported";

--- a/Latest/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Latest/Resources/zh-Hans.lproj/Localizable.strings
@@ -114,13 +114,19 @@
 /* Action to update a given app outside of Latest. The placeholder is filled with the name of the external updater. (App Store, App Name) */
 "ExternalUpdateAction" = "在 %@ 中更新";
 "UnsupportedLabel" = "不支持";
-"LimitedSupportLabel" = "有限支持";
+"LimitedSupportLabel" = "通过 Homebrew 更新";
 "NoSupportDescription" = "更新信息不可用，请查看应用或其官网以管理更新。";
 "SupportedCompactLabel" = "支持";
 "LimitedSupportCompactLabel" = "有限";
 "SupportedLabel" = "支持";
 "UnsupportedCompactLabel" = "不支持";
 "SingleCombinedVersionFormat" = "版本: %@";
-"LimitedSupportDescription" = "更新信息通常可用，但有时可能过时或不准确。无法直接在此处执行更新。";
+"LimitedSupportDescription" = "该应用可通过 Homebrew 更新。在已安装 Homebrew 时，Latest 可以调用 brew 命令执行更新。";
 "FullSupportDescription" = "完全支持。提供可靠的版本信息，可直接在应用内管理更新。\n\n如果显示的版本信息不准确，请随时写一个问题报告。";
 "CombinedVersionFormat" = "版本: %1$@ → %2$@";
+"HomebrewUpdateFailedError" = "Homebrew 更新失败";
+"HomebrewCommandFailedError" = "brew %@ 执行失败。";
+"HomebrewRunningUpdateStatus" = "正在执行 brew update";
+"HomebrewRunningReinstallStatus" = "正在执行 brew reinstall --cask --force %@";
+"HomebrewNotFoundError" = "未找到 Homebrew";
+"HomebrewNotFoundErrorDescription" = "请安装 Homebrew 以通过 Latest 更新 cask 应用。";


### PR DESCRIPTION
Hi, first of all, thank you for creating this project. I really like this tool and appreciate the work you’ve put into it.

I personally have a strong habit of keeping my apps up to date, so this project is especially useful to me. While using it, I noticed that many apps are currently in a limited state and can only be updated manually. Because of that, I tried adding support for updating those apps through Homebrew, using brew reinstall --cask --force.

Along with that, I also adjusted the description and colors for the limited support state, with the colors inspired by Homebrew’s visual style.

This is a relatively significant change, so I’d like to use this PR as a starting point for discussion: whether this direction makes sense for the project, and whether the implementation approach is appropriate.

Thanks again for the great app — I’d be very happy to hear your thoughts.