### PR TITLE
Combine directory monitoring fixes into one implementation

### DIFF
--- a/Latest/Interface/Main Window/Window Controllers/MainWindowController.swift
+++ b/Latest/Interface/Main Window/Window Controllers/MainWindowController.swift
@@ -50,6 +50,8 @@ class MainWindowController: NSWindowController, NSMenuItemValidation, NSMenuDele
     
     /// The button that triggers all available updates to be done
     @IBOutlet weak var updateAllButton: NSButton!
+
+	private var presentedObservationFailures = Set<String>()
         
     override func windowDidLoad() {
         super.windowDidLoad()
@@ -196,6 +198,21 @@ class MainWindowController: NSWindowController, NSMenuItemValidation, NSMenuDele
 		self.progressIndicator.isHidden = true
         self.updateAllButton.isEnabled = hasUpdatesAvailable
 	}
+
+	func updateChecker(_ updateChecker: UpdateCheckCoordinator, didFailToObserveDirectoryAt url: URL, error: Error) {
+		let failureKey = "\(url.path)|\(error.localizedDescription)"
+		guard presentedObservationFailures.insert(failureKey).inserted else { return }
+		NSApplication.shared.requestUserAttention(.informationalRequest)
+		
+		guard let window = self.window else { return }
+		
+		let alert = NSAlert()
+		alert.alertStyle = .warning
+		alert.messageText = NSLocalizedString("DirectoryObservationFailedAlertTitle", comment: "Title of alert shown when Latest cannot monitor a configured app scan directory.")
+		alert.informativeText = self.directoryObservationFailureMessage(for: url, error: error)
+		alert.addButton(withTitle: NSLocalizedString("OKAction", comment: "Default button for dismissing an informational alert."))
+		alert.beginSheetModal(for: window)
+	}
     
 	
 	// MARK: - Actions
@@ -241,6 +258,21 @@ class MainWindowController: NSWindowController, NSMenuItemValidation, NSMenuDele
             self.listViewController.selectApp(at: nil)
         }
     }
+
+	private func directoryObservationFailureMessage(for url: URL, error: Error) -> String {
+		let format = NSLocalizedString("DirectoryObservationFailedAlertMessage", comment: "Alert text shown when Latest cannot monitor a configured app scan directory. The first placeholder is the directory path, the second is the localized system error.")
+		var message = String.localizedStringWithFormat(format, url.path, error.localizedDescription)
+		
+		let nsError = error as NSError
+		if nsError.domain == NSPOSIXErrorDomain,
+		   let code = POSIXErrorCode(rawValue: Int32(nsError.code)),
+		   code == .EACCES || code == .EPERM {
+			let recovery = NSLocalizedString("DirectoryObservationFailedPermissionSuggestion", comment: "Additional suggestion shown when the app likely lacks permission to observe a scan directory.")
+			message += "\n\n\(recovery)"
+		}
+		
+		return message
+	}
 	
 }
 

--- a/Latest/Model/Directory/AppDirectory.swift
+++ b/Latest/Model/Directory/AppDirectory.swift
@@ -7,9 +7,13 @@
 //
 
 import Cocoa
+import CoreServices
 
 /// The folder listener listens for changes in the given directory and then runs the update checker on changes
 class AppDirectory {
+
+	typealias DescriptorProvider = (URL) -> (descriptor: CInt, error: Error?)
+	typealias ObservationErrorHandler = (URL, Error) -> Void
 	
 	/// The url on which the listener reacts to changes on
 	let url : URL
@@ -29,41 +33,158 @@ class AppDirectory {
 	/// The queue on which updates to the collection are being performed.
 	private var collectionQueue = DispatchQueue(label: "DataStoreQueue")
 
+	private let descriptorProvider: DescriptorProvider
+	private let observationErrorHandler: ObservationErrorHandler?
+
 	
-	/// The file system listener
-	private lazy var listener : DispatchSourceFileSystemObject = {
-		let descriptor = open((self.url as NSURL).fileSystemRepresentation, O_EVTONLY)
-		guard descriptor != -1 else { fatalError("Unable to open folder at url") }
-		
-		let source = DispatchSource.makeFileSystemObjectSource(fileDescriptor: descriptor,
-															   eventMask: .write)
-		
-		source.setEventHandler(handler: collectBundles)
-		
-		return source
-	}()
+	/// Recursive file system listener for the tracked directory.
+	private lazy var listener = RecursiveDirectoryMonitor(url: self.url, queue: collectionQueue) { [weak self] in
+		self?.collectBundles()
+	}
 	
 	/// Initializes the class and resumes the listener automatically
-	init(url: URL, updateHandler: @escaping UpdateHandler) {
+	init(
+		url: URL,
+		updateHandler: @escaping UpdateHandler,
+		descriptorProvider: @escaping DescriptorProvider = AppDirectory.openDescriptor,
+		observationErrorHandler: ObservationErrorHandler? = nil
+	) {
 		self.url = url
 		self.handler = updateHandler
+		self.descriptorProvider = descriptorProvider
+		self.observationErrorHandler = observationErrorHandler
 		
 		resumeTracking()
 	}
 	
 	deinit {
-		listener.cancel()
+		listener.stop()
 	}
 	
 	/// Resumes tracking if it is not already running
 	private func resumeTracking() {
-		listener.activate()
+		guard canObserveDirectory() else {
+			collectBundles()
+			return
+		}
+		
+		if let error = listener.start() {
+			observationErrorHandler?(url, error)
+		}
 		collectBundles()
 	}
 	
 	/// Triggers an update run
 	private func collectBundles() {
 		bundles = BundleCollector.collectBundles(at: self.url)
+	}
+
+	private func canObserveDirectory() -> Bool {
+		let result = descriptorProvider(url)
+		guard result.descriptor != -1 else {
+			if let error = result.error {
+				observationErrorHandler?(url, error)
+			}
+			return false
+		}
+		
+		close(result.descriptor)
+		return true
+	}
+
+	private static func openDescriptor(for url: URL) -> (descriptor: CInt, error: Error?) {
+		let descriptor = open((url as NSURL).fileSystemRepresentation, O_EVTONLY)
+		guard descriptor == -1 else {
+			return (descriptor, nil)
+		}
+		
+		let error = NSError(domain: NSPOSIXErrorDomain, code: Int(errno), userInfo: [
+			NSFilePathErrorKey: url.path
+		])
+		return (-1, error)
+	}
+	
+}
+
+/// Recursive directory monitor backed by FSEvents.
+private final class RecursiveDirectoryMonitor {
+	
+	typealias EventHandler = () -> Void
+	
+	private let url: URL
+	private let queue: DispatchQueue
+	private let eventHandler: EventHandler
+	private var stream: FSEventStreamRef?
+	private var isStarted = false
+	
+	init(url: URL, queue: DispatchQueue, eventHandler: @escaping EventHandler) {
+		self.url = url
+		self.queue = queue
+		self.eventHandler = eventHandler
+	}
+	
+	deinit {
+		stop()
+	}
+	
+	func start() -> Error? {
+		guard !isStarted else { return nil }
+		guard let stream = makeStream() else {
+			return Self.makeStartError(for: url)
+		}
+		
+		self.stream = stream
+		FSEventStreamSetDispatchQueue(stream, queue)
+		guard FSEventStreamStart(stream) else {
+			stop()
+			return Self.makeStartError(for: url)
+		}
+		
+		isStarted = true
+		return nil
+	}
+	
+	func stop() {
+		guard let stream else { return }
+		
+		FSEventStreamStop(stream)
+		FSEventStreamInvalidate(stream)
+		FSEventStreamRelease(stream)
+		self.stream = nil
+		isStarted = false
+	}
+	
+	private func makeStream() -> FSEventStreamRef? {
+		var context = FSEventStreamContext(
+			version: 0,
+			info: UnsafeMutableRawPointer(Unmanaged.passUnretained(self).toOpaque()),
+			retain: nil,
+			release: nil,
+			copyDescription: nil
+		)
+		
+		let flags = UInt32(kFSEventStreamCreateFlagUseCFTypes | kFSEventStreamCreateFlagFileEvents)
+		
+		return FSEventStreamCreate(
+			nil,
+			{ _, info, _, _, _, _ in
+				guard let info else { return }
+				let monitor = Unmanaged<RecursiveDirectoryMonitor>.fromOpaque(info).takeUnretainedValue()
+				monitor.eventHandler()
+			},
+			&context,
+			[url.path] as CFArray,
+			FSEventStreamEventId(kFSEventStreamEventIdSinceNow),
+			0.5,
+			flags
+		)
+	}
+	
+	private static func makeStartError(for url: URL) -> Error {
+		NSError(domain: NSCocoaErrorDomain, code: NSFileReadUnknownError, userInfo: [
+			NSLocalizedDescriptionKey: NSLocalizedString("DirectoryObservationUnavailableError", comment: "Error shown when Latest cannot start recursive monitoring for a configured app scan directory."),
+			NSFilePathErrorKey: url.path
+		])
 	}
 	
 }

--- a/Latest/Model/Directory/AppLibrary.swift
+++ b/Latest/Model/Directory/AppLibrary.swift
@@ -13,7 +13,9 @@ class AppLibrary {
 	
 	/// The handler to be called when apps change locally.
 	typealias UpdateHandler = ([App.Bundle]) -> Void
+	typealias ObservationFailureHandler = (URL, Error) -> Void
 	let updateHandler: UpdateHandler
+	let observationFailureHandler: ObservationFailureHandler
 	
 	/// A list of all application bundles that are available locally.
 	var bundles: [App.Bundle] {
@@ -21,10 +23,12 @@ class AppLibrary {
 	}
 		
 	private var directories = [URL: AppDirectory]()
+	private var reportedObservationFailures = Set<URL>()
 	
 	/// Initializes the library with the given handler for updates.
-	init(handler: @escaping UpdateHandler) {
+	init(handler: @escaping UpdateHandler, observationFailureHandler: @escaping ObservationFailureHandler = { _, _ in }) {
 		self.updateHandler = handler
+		self.observationFailureHandler = observationFailureHandler
 	}
 	
 	private lazy var updateScheduler: DispatchSourceUserDataAdd = {
@@ -54,37 +58,62 @@ class AppLibrary {
 	}
 		
 	private func setupDirectoryObservers() {
-		// Use a dispatch group for the initial setup to get contents for all directories before gathering apps
-		var dispatchGroup: DispatchGroup? = self.directories.isEmpty ? DispatchGroup() : nil
+		// Use a dispatch group for the initial setup to get contents for all directories before gathering apps.
+		// New directory observers may emit more than once during startup, but the initial load must only
+		// satisfy the group a single time.
+		let dispatchGroup = self.directories.isEmpty ? DispatchGroup() : nil
+		let existingDirectories = self.directories
 		
 		// Setup directories
 		directories = Dictionary(uniqueKeysWithValues: directoryStore.URLs.compactMap { url in
 			// Skip unreachable directories
 			guard directoryStore.isReachable(url) else { return nil }
 			
-			dispatchGroup?.enter()
-			
 			// Reuse existing directory observations if possible
-			return (url, directories[url] ?? AppDirectory(url: url) {
-				if let dispatchGroup {
-					// Initial mode, notify dispatch group
-					dispatchGroup.leave()
-				} else {
-					// Schedule update
-					self.updateScheduler.add(data: 1)
+			if let existingDirectory = existingDirectories[url] {
+				return (url, existingDirectory)
+			}
+			
+			dispatchGroup?.enter()
+			let initialLoadLock = NSLock()
+			var initialLoadCompleted = false
+			
+			return (url, AppDirectory(
+				url: url,
+				updateHandler: {
+					initialLoadLock.lock()
+					let isInitialLoad = !initialLoadCompleted
+					if isInitialLoad {
+						initialLoadCompleted = true
+					}
+					initialLoadLock.unlock()
+					
+					if isInitialLoad {
+						dispatchGroup?.leave()
+					} else {
+						// Schedule update
+						self.updateScheduler.add(data: 1)
+					}
+				},
+				observationErrorHandler: { url, error in
+					self.reportObservationFailure(for: url, error: error)
 				}
-			})
+			))
 		})
 		
 		dispatchGroup?.notify(queue: .global()) {
 			// Call update immediately. Using the scheduler delays the update.
 			self.performUpdate()
-			dispatchGroup = nil
 		}
 	}
 	
 	private func performUpdate() {
 		updateHandler(bundles)
+	}
+
+	private func reportObservationFailure(for url: URL, error: Error) {
+		guard reportedObservationFailures.insert(url).inserted else { return }
+		observationFailureHandler(url, error)
 	}
 
 	

--- a/Latest/Model/UpdateCheckCoordinator.swift
+++ b/Latest/Model/UpdateCheckCoordinator.swift
@@ -27,6 +27,9 @@ protocol UpdateCheckProgressReporting : AnyObject {
 
 	/// Called after the update checker finished checking for updates.
 	func updateCheckerDidFinishCheckingForUpdates(_ updateChecker: UpdateCheckCoordinator)
+
+	/// Called when an app scan directory cannot be monitored for filesystem changes.
+	func updateChecker(_ updateChecker: UpdateCheckCoordinator, didFailToObserveDirectoryAt url: URL, error: Error)
 	
 }
 
@@ -60,11 +63,18 @@ class UpdateCheckCoordinator {
 	
 	/// The library containing all bundles loaded from disk.
 	private lazy var library: AppLibrary = {
-		return AppLibrary { bundles in
-			// Set new bundles and check for updates
-			let newApps = self.dataStore.set(appBundles: Set(bundles))
-			self.runUpdateCheck(on: newApps.map({ $0.bundle }))
-		}
+		return AppLibrary(
+			handler: { bundles in
+				// Set new bundles and check for updates
+				let newApps = self.dataStore.set(appBundles: Set(bundles))
+				self.runUpdateCheck(on: newApps.map({ $0.bundle }))
+			},
+			observationFailureHandler: { url, error in
+				DispatchQueue.main.async {
+					self.progressDelegate?.updateChecker(self, didFailToObserveDirectoryAt: url, error: error)
+				}
+			}
+		)
 	}()
 	
 	/// The data store updated apps should be passed to

--- a/Latest/Resources/en.lproj/Localizable.strings
+++ b/Latest/Resources/en.lproj/Localizable.strings
@@ -28,6 +28,18 @@
 /* Update date sorting option. Displayed in menu with title: 'Sort By' -> 'Date' */
 "DateSortOption" = "Date";
 
+/* Alert text shown when Latest cannot monitor a configured app scan directory. The first placeholder is the directory path, the second is the localized system error. */
+"DirectoryObservationFailedAlertMessage" = "Latest could not monitor this app folder for changes:\n%@\n\nReason: %@\n\nLatest will continue with a one-time scan, but changes in this folder may not be detected automatically.";
+
+/* Title of alert shown when Latest cannot monitor a configured app scan directory. */
+"DirectoryObservationFailedAlertTitle" = "Couldn’t Monitor App Folder";
+
+/* Error shown when Latest cannot start recursive monitoring for a configured app scan directory. */
+"DirectoryObservationUnavailableError" = "Latest could not start recursive monitoring for this folder.";
+
+/* Additional suggestion shown when the app likely lacks permission to observe a scan directory. */
+"DirectoryObservationFailedPermissionSuggestion" = "If this looks like a permissions problem, review macOS Privacy & Security settings and folder access for Latest.";
+
 /* Update progress state of downloading an update. The first %@ stands for the already downloaded bytes, the second one for the total amount of bytes. One expected output would be 'Downloading 3 MB of 21 MB' */
 "DownloadingUpdateStatus" = "Downloading %@ of %@";
 
@@ -87,6 +99,9 @@
 
 /* Action to open the app. */
 "OpenAction" = "Open";
+
+/* Default button for dismissing an informational alert. */
+"OKAction" = "OK";
 
 /* Short description of error that no release notes were found. */
 "ReleaseNotesUnavailableError" = "No Release Notes";

--- a/Latest/View Model/AppListSettings.swift
+++ b/Latest/View Model/AppListSettings.swift
@@ -53,7 +53,7 @@ struct AppListSettings: Observable {
 		}
 		
 		get {
-			SortOptions(rawValue: UserDefaults.standard.integer(forKey: SortOptionsKey))!
+			SortOptions(rawValue: UserDefaults.standard.integer(forKey: SortOptionsKey)) ?? .updateDate
 		}
 	}
 	

--- a/Tests/OSVersionTest.swift
+++ b/Tests/OSVersionTest.swift
@@ -39,3 +39,95 @@ class OSVersionTest: XCTestCase {
 	}
 	
 }
+
+final class AppDirectoryTest: XCTestCase {
+
+	func testInitFallsBackToSingleScanWhenDirectoryCannotBeObserved() throws {
+		let url = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+		try FileManager.default.createDirectory(at: url, withIntermediateDirectories: false)
+		defer {
+			try? FileManager.default.removeItem(at: url)
+		}
+
+		let updateExpectation = expectation(description: "directory scan completes")
+		let observationError = NSError(domain: NSPOSIXErrorDomain, code: Int(EACCES), userInfo: nil)
+		var reportedFailure: (url: URL, error: NSError)?
+
+		let directory = AppDirectory(
+			url: url,
+			updateHandler: {
+				updateExpectation.fulfill()
+			},
+			descriptorProvider: { _ in
+				(-1, observationError)
+			},
+			observationErrorHandler: { failedURL, error in
+				reportedFailure = (failedURL, error as NSError)
+			}
+		)
+
+		wait(for: [updateExpectation], timeout: 1)
+		XCTAssertEqual(directory.bundles.count, 0)
+		XCTAssertEqual(reportedFailure?.url, url)
+		XCTAssertEqual(reportedFailure?.error.domain, NSPOSIXErrorDomain)
+		XCTAssertEqual(reportedFailure?.error.code, Int(EACCES))
+	}
+
+	func testNestedSubfolderChangesTriggerRefresh() throws {
+		let fileManager = FileManager.default
+		let rootURL = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+			.appendingPathComponent("Latest-AppDirectoryTest-\(UUID().uuidString)", isDirectory: true)
+		let nestedURL = rootURL.appendingPathComponent("Browsers", isDirectory: true)
+		
+		try fileManager.createDirectory(at: nestedURL, withIntermediateDirectories: true)
+		defer { try? fileManager.removeItem(at: rootURL) }
+		
+		let initialScan = expectation(description: "Initial scan completes")
+		let nestedChange = expectation(description: "Nested change triggers rescan")
+		
+		var callbackCount = 0
+		var directory: AppDirectory?
+		directory = AppDirectory(url: rootURL) {
+			callbackCount += 1
+			
+			if callbackCount == 1 {
+				initialScan.fulfill()
+			}
+			
+			if directory?.bundles.contains(where: { $0.name == "Nested App" }) == true {
+				nestedChange.fulfill()
+			}
+		}
+		
+		wait(for: [initialScan], timeout: 2)
+		
+		try Self.createAppBundle(
+			named: "Nested App",
+			identifier: "com.example.nested-app",
+			at: nestedURL.appendingPathComponent("Nested App.app", isDirectory: true)
+		)
+		
+		wait(for: [nestedChange], timeout: 5)
+		XCTAssertEqual(directory?.bundles.count, 1)
+		XCTAssertEqual(directory?.bundles.first?.name, "Nested App")
+	}
+
+	private static func createAppBundle(named name: String, identifier: String, at url: URL) throws {
+		let fileManager = FileManager.default
+		let contentsURL = url.appendingPathComponent("Contents", isDirectory: true)
+		
+		try fileManager.createDirectory(at: contentsURL, withIntermediateDirectories: true)
+		
+		let infoPlist: [String: Any] = [
+			"CFBundleIdentifier": identifier,
+			"CFBundleName": name,
+			"CFBundlePackageType": "APPL",
+			"CFBundleShortVersionString": "1.0",
+			"CFBundleVersion": "1"
+		]
+		
+		let data = try PropertyListSerialization.data(fromPropertyList: infoPlist, format: .xml, options: 0)
+		try data.write(to: contentsURL.appendingPathComponent("Info.plist"))
+	}
+
+}


### PR DESCRIPTION
## Summary
This PR combines the work that was previously split across #559, #561, and #562 into one coherent implementation for app-directory discovery and monitoring.

Instead of merging three overlapping changes that each patch one failure mode, this PR reshapes the `AppDirectory` / `AppLibrary` path so Latest now has a single directory-monitoring design that:
- keeps startup resilient when a configured scan directory cannot be observed
- prevents the startup `DispatchGroup` imbalance that could crash during initial directory setup
- watches application directories recursively so nested subfolder changes are detected
- visibly alerts the user when a directory cannot be monitored, including the failing path and the system error

Supersedes:
- #559
- #561
- #562

## What Changed
### 1. Replace the root-only watcher with recursive monitoring
`AppDirectory` now uses a recursive FSEvents-based monitor instead of a single `DispatchSourceFileSystemObject` on the root directory.

That means the live watcher now matches what the initial scan already did: recursively discover apps below the configured application roots.

This resolves the subfolder refresh gap described in #562.

### 2. Keep startup alive when monitoring cannot be established
If a configured scan path cannot be monitored, Latest no longer crashes.

Instead:
- the path is still scanned once, so startup can continue
- the observation failure is captured as a real error with the relevant path
- the rest of the update-check flow proceeds normally

This preserves the resilience work from #559.

### 3. Surface observation failures to the user through native macOS UI
Following the request in the last user comment on #559, Latest now visibly alerts the user when a scan directory cannot be monitored.

The app:
- requests user attention from macOS
- presents a native warning sheet on the main window
- shows the exact folder path that failed
- includes the localized system error
- adds an extra hint when the failure looks like a permissions problem (`EACCES` / `EPERM`)

This turns the degraded path from a silent fallback into something the user can actually act on.

### 4. Fix startup callback accounting in `AppLibrary`
`AppLibrary.setupDirectoryObservers()` still uses a `DispatchGroup` to wait for each newly created `AppDirectory` to complete its initial scan.

The previous implementation assumed that a new observer would only produce one callback during startup. In practice, that assumption could fail and lead to an unbalanced `dispatch_group_leave()` crash.

This PR makes the startup completion path one-shot per new observer, and routes all later callbacks through the existing deferred update scheduler.

This absorbs the fix from #561.

## Files / Areas Touched
- `Latest/Model/Directory/AppDirectory.swift`
- `Latest/Model/Directory/AppLibrary.swift`
- `Latest/Model/UpdateCheckCoordinator.swift`
- `Latest/Interface/Main Window/Window Controllers/MainWindowController.swift`
- `Latest/Resources/en.lproj/Localizable.strings`
- `Tests/OSVersionTest.swift`

## Behavioral Result
After this PR:
- Latest no longer crashes when a scan directory cannot be observed
- nested app folders trigger refreshes without needing a restart or manual rescan
- startup no longer risks the duplicate `DispatchGroup.leave()` crash
- users get a visible in-app warning when directory observation fails, with enough detail to identify the problematic path

## Verification
Build:
- `xcodebuild -project Latest.xcodeproj -scheme Latest -configuration Debug CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY= build`
- result: succeeded

Tests:
- the regression coverage added here includes:
  - fallback when a directory cannot be observed
  - recursive refresh when an app bundle appears in a nested subfolder
- full `xcodebuild test` is still blocked in this environment by the existing test-target dependency problem resolving `CommerceKit` / `StoreFoundation` when importing `Latest`

## Notes
The point of this PR is to leave the project with one maintainable end state instead of three partially overlapping branches that all modify directory observation for different reasons.
