### PR TITLE
Use the user's language for MAS release notes

### DIFF
--- a/Latest.xcodeproj/project.pbxproj
+++ b/Latest.xcodeproj/project.pbxproj
@@ -77,6 +77,7 @@
 		50DAEF4421047FA900B32E8A /* UpdateItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50DAEF4321047FA900B32E8A /* UpdateItemView.swift */; };
 		50E4EB072B17DACB00A70A7D /* VersionParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50E4EB062B17DACB00A70A7D /* VersionParser.swift */; };
 		50E4EB092B17DFCE00A70A7D /* VersionParserTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50E4EB082B17DFCE00A70A7D /* VersionParserTest.swift */; };
+		50E8D1E42D2795CB0099A1E8 /* MacAppStoreCheckerOperationTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50E8D1E32D2795CB0099A1E8 /* MacAppStoreCheckerOperationTest.swift */; };
 		50FEB87D2B1BE630006FB75D /* OSVersionTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50FEB87C2B1BE630006FB75D /* OSVersionTest.swift */; };
 		50FEB87F2B1BE67F006FB75D /* VersionSanitizationTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50FEB87E2B1BE67E006FB75D /* VersionSanitizationTest.swift */; };
 		50FEB8812B1D2402006FB75D /* ExcludedAppIdentifiers.plist in Resources */ = {isa = PBXBuildFile; fileRef = 50FEB8802B1D2402006FB75D /* ExcludedAppIdentifiers.plist */; };
@@ -299,6 +300,7 @@
 		50DAEF4321047FA900B32E8A /* UpdateItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateItemView.swift; sourceTree = "<group>"; };
 		50E4EB062B17DACB00A70A7D /* VersionParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VersionParser.swift; sourceTree = "<group>"; };
 		50E4EB082B17DFCE00A70A7D /* VersionParserTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VersionParserTest.swift; sourceTree = "<group>"; };
+		50E8D1E32D2795CB0099A1E8 /* MacAppStoreCheckerOperationTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacAppStoreCheckerOperationTest.swift; sourceTree = "<group>"; };
 		50E65CDD247A84BC00DFEB47 /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/Main.strings; sourceTree = "<group>"; };
 		50E65CDE247A84E700DFEB47 /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = fr; path = fr.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
 		50E65CE0247A84F300DFEB47 /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -641,6 +643,7 @@
 			isa = PBXGroup;
 			children = (
 				50C81D6D1FBADC5900324C2E /* Info.plist */,
+				50E8D1E32D2795CB0099A1E8 /* MacAppStoreCheckerOperationTest.swift */,
 				50FEB87C2B1BE630006FB75D /* OSVersionTest.swift */,
 				50C81D731FBADC9100324C2E /* VersionTest.swift */,
 				50E4EB082B17DFCE00A70A7D /* VersionParserTest.swift */,
@@ -996,6 +999,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				50C81D741FBADC9100324C2E /* VersionTest.swift in Sources */,
+				50E8D1E42D2795CB0099A1E8 /* MacAppStoreCheckerOperationTest.swift in Sources */,
 				50FEB87D2B1BE630006FB75D /* OSVersionTest.swift in Sources */,
 				50FEB87F2B1BE67F006FB75D /* VersionSanitizationTest.swift in Sources */,
 				50E4EB092B17DFCE00A70A7D /* VersionParserTest.swift in Sources */,

--- a/Latest/Model/Update Checker Extensions/App Store/MacAppStoreCheckerOperation.swift
+++ b/Latest/Model/Update Checker Extensions/App Store/MacAppStoreCheckerOperation.swift
@@ -148,6 +148,9 @@ extension MacAppStoreUpdateCheckerOperation {
 			URLQueryItem(name: "country", value: languageCode),
 			URLQueryItem(name: "bundleId", value: self.app.bundleIdentifier)
 		]
+		if let storefrontLanguage = Self.storefrontLanguageIdentifier() {
+			components?.queryItems?.append(URLQueryItem(name: "lang", value: storefrontLanguage))
+		}
 		guard let url = components?.url else {
 			completion(.failure(MalformedURLError))
 			return
@@ -176,6 +179,25 @@ extension MacAppStoreUpdateCheckerOperation {
 		}
 		
 		dataTask.resume()
+	}
+
+	/// Returns the App Store Search API language override for the user's preferred language, if supported.
+	///
+	/// The Search API documents `en_us` and `ja_jp` as supported explicit language values.
+	static func storefrontLanguageIdentifier(preferredLanguages: [String] = Locale.preferredLanguages) -> String? {
+		guard let preferredLanguage = preferredLanguages.first else {
+			return nil
+		}
+
+		let components = Locale.components(fromIdentifier: preferredLanguage)
+		switch components[NSLocale.Key.languageCode.rawValue]?.lowercased() {
+		case "en":
+			return "en_us"
+		case "ja":
+			return "ja_jp"
+		default:
+			return nil
+		}
 	}
 		
 }

--- a/Tests/MacAppStoreCheckerOperationTest.swift
+++ b/Tests/MacAppStoreCheckerOperationTest.swift
@@ -1,0 +1,33 @@
+//
+//  MacAppStoreCheckerOperationTest.swift
+//  Latest Tests
+//
+//  Created by Codex on 16.03.26.
+//
+
+import XCTest
+@testable import Latest
+
+final class MacAppStoreCheckerOperationTest: XCTestCase {
+
+	func testStorefrontLanguageIdentifierUsesEnglishOverride() {
+		let identifier = MacAppStoreUpdateCheckerOperation.storefrontLanguageIdentifier(preferredLanguages: ["en-HK"])
+		XCTAssertEqual(identifier, "en_us")
+	}
+
+	func testStorefrontLanguageIdentifierUsesJapaneseOverride() {
+		let identifier = MacAppStoreUpdateCheckerOperation.storefrontLanguageIdentifier(preferredLanguages: ["ja-JP"])
+		XCTAssertEqual(identifier, "ja_jp")
+	}
+
+	func testStorefrontLanguageIdentifierSkipsUnsupportedLanguages() {
+		let identifier = MacAppStoreUpdateCheckerOperation.storefrontLanguageIdentifier(preferredLanguages: ["zh-Hant-HK"])
+		XCTAssertNil(identifier)
+	}
+
+	func testStorefrontLanguageIdentifierHandlesMissingPreference() {
+		let identifier = MacAppStoreUpdateCheckerOperation.storefrontLanguageIdentifier(preferredLanguages: [])
+		XCTAssertNil(identifier)
+	}
+
+}


### PR DESCRIPTION
## Summary
- add an App Store Search API `lang` override for supported preferred languages when fetching MAS metadata
- use the user's preferred language to request English (`en_us`) or Japanese (`ja_jp`) release notes in multilingual storefronts
- add focused tests for the storefront-language mapping helper

## Why
In multilingual storefronts such as Hong Kong, requesting only `country=HK` can return storefront-default release notes instead of the same language the user sees in the Mac App Store. Passing `lang=en_us` fixes the Slack example from #219 and keeps the release notes aligned with the user's English UI.

## Validation
- `xcodebuild -project Latest.xcodeproj -scheme Latest -configuration Debug -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY='' build`
- `xcodebuild -project Latest.xcodeproj -scheme Latest -configuration Debug -destination 'platform=macOS' -only-testing:'Latest Tests/MacAppStoreCheckerOperationTest' test CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=''` currently still hits the existing test-target dependency problem resolving `CommerceKit` / `StoreFoundation`

Closes #219.
