### PR TITLE
Fix Sparkle bundle resolution by path

### DIFF
--- a/Latest/Model/Update Checker Extensions/Sparkle/SparkleCheckerOperation.swift
+++ b/Latest/Model/Update Checker Extensions/Sparkle/SparkleCheckerOperation.swift
@@ -62,7 +62,7 @@ class SparkleUpdateCheckerOperation: StatefulOperation, UpdateCheckerOperation, 
 	
 	override func execute() {
 		// Gather app and app bundle
-		guard let bundle = Bundle(identifier: self.app.bundleIdentifier) else {
+		guard let bundle = Bundle(path: self.app.fileURL.path) else {
 			self.finish(with: LatestError.updateInfoUnavailable)
 			return
 		}
@@ -102,7 +102,7 @@ class SparkleUpdateCheckerOperation: StatefulOperation, UpdateCheckerOperation, 
 		
 		// Build update
 		self.update = App.Update(app: self.app, remoteVersion: version, minimumOSVersion: minimumOSVersion, source: .sparkle, date: appcastItem.date, releaseNotes: releaseNotes, updateAction: .builtIn(block: { app in
-			UpdateQueue.shared.addOperation(SparkleUpdateOperation(bundleIdentifier: app.bundleIdentifier, appIdentifier: app.identifier))
+			UpdateQueue.shared.addOperation(SparkleUpdateOperation(bundleURL: app.fileURL, bundleIdentifier: app.bundleIdentifier, appIdentifier: app.identifier))
 		}))
 
 		DispatchQueue.main.async(execute: {

--- a/Latest/Model/Updater/SparkleUpdateOperation.swift
+++ b/Latest/Model/Updater/SparkleUpdateOperation.swift
@@ -12,6 +12,9 @@ import Sparkle
 /// The operation updating Sparkle apps.
 class SparkleUpdateOperation: UpdateOperation, @unchecked Sendable {
 	
+	/// The app bundle location discovered by Latest.
+	private let bundleURL: URL
+	
 	/// The updater used to update this app.
 	private var updater: SPUUpdater?
 	
@@ -22,7 +25,8 @@ class SparkleUpdateOperation: UpdateOperation, @unchecked Sendable {
 	private let progressScheduler: DispatchSourceUserDataAdd
 	
 	/// Initializes the operation with the given Sparkle app and handler
-	override init(bundleIdentifier: String, appIdentifier: App.Bundle.Identifier) {
+	init(bundleURL: URL, bundleIdentifier: String, appIdentifier: App.Bundle.Identifier) {
+		self.bundleURL = bundleURL
 		self.progressScheduler = DispatchSource.makeUserDataAddSource(queue: .global())
 		super.init(bundleIdentifier: bundleIdentifier, appIdentifier: appIdentifier)
 
@@ -47,7 +51,7 @@ class SparkleUpdateOperation: UpdateOperation, @unchecked Sendable {
 		super.execute()
 		
 		// Gather app and app bundle
-		guard let bundle = Bundle(identifier: self.bundleIdentifier) else {
+		guard let bundle = Bundle(path: self.bundleURL.path) else {
 			self.finish(with: LatestError.updateInfoUnavailable)
 			return
 		}


### PR DESCRIPTION
## Summary
- use the discovered app bundle path for Sparkle check/update operations
- stop relying on `Bundle(identifier:)` for system-wide app resolution in the Sparkle path
- keep the existing update flow otherwise unchanged

## Testing
- `xcodebuild -project Latest.xcodeproj -scheme Latest -configuration Debug CODE_SIGNING_ALLOWED=NO build`
