### PR TITLE
Fix Latest Tests target build: missing framework/module search paths

### DIFF
--- a/Latest.xcodeproj/project.pbxproj
+++ b/Latest.xcodeproj/project.pbxproj
@@ -1594,6 +1594,11 @@
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEAD_CODE_STRIPPING = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					/System/Library/PrivateFrameworks,
+					"$(PROJECT_DIR)/Frameworks",
+				);
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = Tests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1603,6 +1608,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "com.max-langer.Latest-Tests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_INCLUDE_PATHS = "$(inherited) $(SRCROOT)/Frameworks/CommerceKit $(SRCROOT)/Frameworks/StoreFoundation";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Latest.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Latest";
 			};
@@ -1619,6 +1625,11 @@
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEAD_CODE_STRIPPING = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					/System/Library/PrivateFrameworks,
+					"$(PROJECT_DIR)/Frameworks",
+				);
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = Tests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1628,6 +1639,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "com.max-langer.Latest-Tests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_INCLUDE_PATHS = "$(inherited) $(SRCROOT)/Frameworks/CommerceKit $(SRCROOT)/Frameworks/StoreFoundation";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Latest.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Latest";
 			};


### PR DESCRIPTION
The `Latest Tests` target currently fails to build: `@testable import Latest` needs the vendored CommerceKit/StoreFoundation module maps, but only the app target declares `FRAMEWORK_SEARCH_PATHS` and `SWIFT_INCLUDE_PATHS` for them.

```
error: unable to resolve module dependency: 'CommerceKit' (in target 'Latest Tests')
```

This mirrors both settings onto the test target's Debug/Release configurations. With this change the suite builds and runs (verified with Xcode 26.6 on macOS 26.6).

Found while modernizing a fork ([GitDonkeyHubbed/Latest](https://github.com/GitDonkeyHubbed/Latest), branch `rj-main`). Full disclosure: the work was done with AI assistance (Claude), with every change build- and test-verified before committing.