### PR TITLE
Fix version comparison: empty-version equality and semver build metadata

### DIFF
--- a/Latest/Model/Version/Version.swift
+++ b/Latest/Model/Version/Version.swift
@@ -50,8 +50,10 @@ struct Version : Hashable, Comparable {
 	// MARK: - Hashing
 	
 	func hash(into hasher: inout Hasher) {
-		hasher.combine(versionNumber)
-		hasher.combine(buildNumber)
+		// Comparison ignores semver build metadata, so hashing must as well —
+		// equal values are required to produce equal hashes.
+		hasher.combine(versionNumber?.strippingBuildMetadata)
+		hasher.combine(buildNumber?.strippingBuildMetadata)
 	}
 	
 	

--- a/Latest/Model/Version/Version.swift
+++ b/Latest/Model/Version/Version.swift
@@ -76,9 +76,17 @@ struct Version : Hashable, Comparable {
 			v1 = lhs.versionNumber
 			v2 = rhs.versionNumber
 		}
-		
+
+		// Semantic-versioning build metadata (a trailing "+…" suffix) carries no
+		// precedence: "3.6.1000+next.05e2e51d52" is the same version as "3.6.1000".
+		// Comparing it produces phantom updates for apps whose feeds annotate
+		// versions with build hashes, so it is ignored on both sides.
+		v1 = v1?.strippingBuildMetadata
+		v2 = v2?.strippingBuildMetadata
+
 		guard let c1 = v1?.components(), let c2 = v2?.components() else {
-			return .undefined
+			// Two versions without any comparable content are equal to each other.
+			return (v1 == nil && v2 == nil) ? .equal : .undefined
 		}
 		
 		let count1 = c1.count
@@ -365,3 +373,19 @@ extension OperatingSystemVersion {
 	
 }
 
+
+// MARK: - Semantic Versioning
+
+private extension String {
+
+	/// The version string with any semantic-versioning build metadata removed.
+	///
+	/// Build metadata is the part after a "+" ("3.6.1000+next.05e2e51d52"). Per
+	/// the semantic-versioning specification it must be ignored when determining
+	/// version precedence.
+	var strippingBuildMetadata: String {
+		guard let index = self.firstIndex(of: "+") else { return self }
+		return String(self[..<index])
+	}
+
+}

--- a/Tests/VersionTest.swift
+++ b/Tests/VersionTest.swift
@@ -166,6 +166,28 @@ class VersionTest: XCTestCase {
         self.newer(v1, v2)
     }
 	
+	func testBuildMetadataIgnored() {
+		// Semver build metadata ("+…") does not affect precedence. An installed
+		// "3.6.1000" is the same version as a feed's "3.6.1000+next.05e2e51d52".
+		var v1 = Version(versionNumber: "3.6.1000", buildNumber: nil)
+		var v2 = Version(versionNumber: "3.6.1000+next.05e2e51d52", buildNumber: nil)
+		self.equal(v1, v2)
+
+		v1 = Version(versionNumber: "0.4.20+1", buildNumber: nil)
+		v2 = Version(versionNumber: "0.4.20", buildNumber: "1")
+		self.equal(v1, v2)
+
+		// A real version bump still wins over any metadata.
+		v1 = Version(versionNumber: "0.4.19+2", buildNumber: nil)
+		v2 = Version(versionNumber: "0.4.20", buildNumber: nil)
+		self.older(v1, v2)
+
+		// Metadata on build numbers is ignored as well.
+		v1 = Version(versionNumber: "2.1.5", buildNumber: "215+abc")
+		v2 = Version(versionNumber: "2.1.5", buildNumber: "215")
+		self.equal(v1, v2)
+	}
+
 	func testNumeralSystems() {
 		// Western arabic numerals
 		var v1 = Version(versionNumber: "3.1.5", buildNumber: nil)

--- a/Tests/VersionTest.swift
+++ b/Tests/VersionTest.swift
@@ -186,6 +186,13 @@ class VersionTest: XCTestCase {
 		v1 = Version(versionNumber: "2.1.5", buildNumber: "215+abc")
 		v2 = Version(versionNumber: "2.1.5", buildNumber: "215")
 		self.equal(v1, v2)
+
+		// The Hashable contract: values comparing equal because metadata is
+		// ignored must also hash equally.
+		v1 = Version(versionNumber: "3.6.1000", buildNumber: nil)
+		v2 = Version(versionNumber: "3.6.1000+next.05e2e51d52", buildNumber: nil)
+		XCTAssertEqual(v1.hashValue, v2.hashValue)
+		XCTAssertEqual(Set([v1, v2]).count, 1)
 	}
 
 	func testNumeralSystems() {


### PR DESCRIPTION
Two comparison bugs in `Version`:

1. **Empty versions compare unequal.** When both selected comparison strings are nil, `compare` returns `.undefined`, so `Version(nil, nil) != Version(nil, nil)` — `testEmptyVersionParsing` fails because of this (reproducible once the test target builds, see #595). Two versions without comparable content now compare equal.

2. **Semver build metadata creates phantom updates.** Feeds that annotate versions with build hashes (e.g. `3.6.1000+next.05e2e51d52`) never match the installed `3.6.1000`, so the app shows an update forever, even immediately after updating. Per the [semver spec](https://semver.org/#spec-item-10), build metadata carries no precedence — it is now stripped on both sides before comparison. A real bump behind metadata (`0.4.19+2` vs `0.4.20`) still registers as an update.

Includes regression tests built from real-world version strings; full suite passes (26/26) together with #595.

From the fork [GitDonkeyHubbed/Latest](https://github.com/GitDonkeyHubbed/Latest). Full disclosure: AI-assisted (Claude), every change build- and test-verified.