### PR TITLE
Fix launch crash: unbalanced dispatch_group_leave in AppLibrary

### DIFF
--- a/Latest/Model/Directory/AppLibrary.swift
+++ b/Latest/Model/Directory/AppLibrary.swift
@@ -55,18 +55,31 @@ class AppLibrary {
 		
 	private func setupDirectoryObservers() {
 		// Use a dispatch group for the initial setup to get contents for all directories before gathering apps
-		var dispatchGroup: DispatchGroup? = self.directories.isEmpty ? DispatchGroup() : nil
-		
+		let dispatchGroup: DispatchGroup? = self.directories.isEmpty ? DispatchGroup() : nil
+
 		// Setup directories
 		directories = Dictionary(uniqueKeysWithValues: directoryStore.URLs.compactMap { url in
 			// Skip unreachable directories
 			guard directoryStore.isReachable(url) else { return nil }
-			
+
 			dispatchGroup?.enter()
-			
+
+			// The callback fires again for every later content change, but the
+			// group must be left exactly once per directory — a directory that
+			// changes again while another one is still listing its initial
+			// contents would otherwise unbalance the group and crash.
+			let initialContentsLock = NSLock()
+			var initialContentsListed = false
+
 			// Reuse existing directory observations if possible
 			return (url, directories[url] ?? AppDirectory(url: url) {
-				if let dispatchGroup {
+				let isInitialContents = initialContentsLock.withCriticalScope { () -> Bool in
+					guard !initialContentsListed else { return false }
+					initialContentsListed = true
+					return true
+				}
+
+				if isInitialContents, let dispatchGroup {
 					// Initial mode, notify dispatch group
 					dispatchGroup.leave()
 				} else {
@@ -75,11 +88,10 @@ class AppLibrary {
 				}
 			})
 		})
-		
+
 		dispatchGroup?.notify(queue: .global()) {
 			// Call update immediately. Using the scheduler delays the update.
 			self.performUpdate()
-			dispatchGroup = nil
 		}
 	}
 	


### PR DESCRIPTION
`AppLibrary.setupDirectoryObservers()` releases the initial-setup `DispatchGroup` from `AppDirectory`'s content callback — but that callback also fires for every subsequent content change. If a watched directory changes again while another directory is still listing its initial contents (e.g. an app is installed or replaced during launch), `leave()` runs twice for one `enter()` and libdispatch traps:

```
BUG IN CLIENT OF LIBDISPATCH: Unbalanced call to dispatch_group_leave()
Thread 3 Crashed:: Dispatch queue: com.apple.root.default-qos
0  libdispatch.dylib  dispatch_group_leave.cold.1 + 36
1  libdispatch.dylib  dispatch_group_leave + 140
2  Latest             AppLibrary … (symbolicated from a 0.12 build)
```

Reproduced on macOS 26.6 by launching Latest while `/Applications` was being modified; happy to attach the full crash report. The fix gives each directory a lock-guarded once-flag so it releases the group exactly once, and routes every later callback to the existing update scheduler. Also removes the `dispatchGroup = nil` inside the notify block, which raced the callbacks.

From the fork [GitDonkeyHubbed/Latest](https://github.com/GitDonkeyHubbed/Latest). Full disclosure: AI-assisted (Claude), verified by symbolicating the crash, applying the fix, and re-testing launch under directory churn.