### PR TITLE
Never crash on unparsable version strings

### DIFF
--- a/Latest/Model/Version/Version.swift
+++ b/Latest/Model/Version/Version.swift
@@ -202,12 +202,15 @@ fileprivate extension String {
 				// Characters that fit no category (e.g. digit-class characters
 				// the scanner cannot consume as a number) must not crash the
 				// app over one odd version string. Consume a single character
-				// as plain text so scanning always advances.
+				// as plain text so scanning always advances. Indices must come
+				// from scanner.string — string indices are not portable between
+				// String instances.
+				let string = scanner.string
 				let index = scanner.currentIndex
-				guard index < self.endIndex else { break }
+				guard index < string.endIndex else { break }
 
-				currentAtoms.append(.string(value: String(self[index])))
-				scanner.currentIndex = self.index(after: index)
+				currentAtoms.append(.string(value: String(string[index])))
+				scanner.currentIndex = string.index(after: index)
 			}
 		}
 		

--- a/Latest/Model/Version/Version.swift
+++ b/Latest/Model/Version/Version.swift
@@ -199,7 +199,15 @@ fileprivate extension String {
 			}
 			
 			else {
-				fatalError("Unable to parse version string: \(self)")
+				// Characters that fit no category (e.g. digit-class characters
+				// the scanner cannot consume as a number) must not crash the
+				// app over one odd version string. Consume a single character
+				// as plain text so scanning always advances.
+				let index = scanner.currentIndex
+				guard index < self.endIndex else { break }
+
+				currentAtoms.append(.string(value: String(self[index])))
+				scanner.currentIndex = self.index(after: index)
 			}
 		}
 		

--- a/Tests/VersionTest.swift
+++ b/Tests/VersionTest.swift
@@ -182,6 +182,27 @@ class VersionTest: XCTestCase {
 		v2 = Version(versionNumber: "२.१.६", buildNumber: nil)
 		self.newer(v1, v2)
 	}
+
+	func testHostileVersionStrings() {
+		// Version strings with characters the scanner cannot classify must
+		// never crash the comparison (the parser used to call fatalError).
+		// Identical hostile strings compare equal…
+		self.equal(Version(versionNumber: "1.2🚀", buildNumber: nil),
+				   Version(versionNumber: "1.2🚀", buildNumber: nil))
+		self.equal(Version(versionNumber: "１.２.３", buildNumber: nil),
+				   Version(versionNumber: "１.２.３", buildNumber: nil))
+
+		// …and comparisons around them stay sane where a numeric prefix exists.
+		self.newer(Version(versionNumber: "3.0", buildNumber: nil),
+				   Version(versionNumber: "2.0\u{01}beta", buildNumber: nil))
+		self.older(Version(versionNumber: "1.9", buildNumber: nil),
+				   Version(versionNumber: "2.0-🚀.5", buildNumber: nil))
+
+		// Mixed scripts, control characters, and replacement characters parse
+		// without trapping regardless of how the atoms are classified.
+		_ = Version(versionNumber: "٣.١🚀.٥", buildNumber: "\u{FFFD}\u{0007}")
+			== Version(versionNumber: "2.2.6", buildNumber: "٢١٧")
+	}
 	
 	
     // MARK: - Helper Methods


### PR DESCRIPTION
The version-string scanner in `Version.swift` calls `fatalError("Unable to parse version string:")` when it encounters a character that fits none of its scan categories (number, separator, letter class). One installed app reporting an unusual version string crashes all of Latest — #572 ("crashes on Intel macOS 14.8.4 with parse error") matches this exactly, and #594 (crash for BetterZip 6) looks like the same failure.

This consumes a single character as a plain-text atom instead, so scanning always advances (no infinite-loop risk) and comparison degrades gracefully for strings the parser can't fully classify.

Adds tests covering emoji, full-width digits, control characters, replacement characters, and mixed numeral scripts — assertions chosen to hold regardless of which scanner branch classifies each character, so they pin the no-crash behavior rather than parser internals. Full suite passes together with #595/#596.

From the fork [GitDonkeyHubbed/Latest](https://github.com/GitDonkeyHubbed/Latest). Full disclosure: AI-assisted (Claude), build- and test-verified.