### PR TITLE
Fix Sparkle update lifecycle races and blocking progress throttle

### DIFF
--- a/Latest/Model/Updater/Sparkle/SparkleUpdateOperation.swift
+++ b/Latest/Model/Updater/Sparkle/SparkleUpdateOperation.swift
@@ -17,72 +17,139 @@ class SparkleUpdateOperation: UpdateOperation, @unchecked Sendable {
 	
 	// Callback to be called when the operation has been cancelled
 	fileprivate var cancellationCallback: (() -> Void)?
-	
-	/// Schedules an progress update notification.
-	private let progressScheduler: DispatchSourceUserDataAdd
-	
+
+	/// The location of the app bundle to update.
+	///
+	/// `App.Bundle.Identifier` is the bundle's file URL, so the identifier the operation was
+	/// created with doubles as the on-disk location of the app being updated.
+	private let fileURL: URL
+
 	/// Initializes the operation with the given Sparkle app and handler
 	override init(bundleIdentifier: String, appIdentifier: App.Bundle.Identifier) {
-		self.progressScheduler = DispatchSource.makeUserDataAddSource(queue: .global())
+		self.fileURL = appIdentifier
 		super.init(bundleIdentifier: bundleIdentifier, appIdentifier: appIdentifier)
-
-		// Delay notifying observers to only let that notification occur in a certain interval
-		self.progressScheduler.setEventHandler() { [weak self] in
-			guard let self = self else { return }
-			
-			// Notify the progress state
-			self.progressState = .downloading(loadedSize: Int64(self.receivedLength), totalSize: Int64(self.expectedContentLength))
-
-			// Delay the next call for 1 second
-			Thread.sleep(forTimeInterval: 1)
-		}
-		
-		self.progressScheduler.activate()
 	}
-	
-	
+
+
 	// MARK: - Operation Overrides
 	
 	override func execute() {
 		super.execute()
-		
-		// Gather app and app bundle
-		guard let bundle = Bundle(identifier: self.bundleIdentifier) else {
+
+		// Gather app and app bundle. `Bundle(identifier:)` only ever resolves bundles that are
+		// already loaded into this process, so it cannot find the app being updated. Load it
+		// from its known location instead, keeping the identifier lookup as a last-resort
+		// fallback.
+		guard let bundle = Bundle(url: self.fileURL) ?? Bundle(path: self.fileURL.path) ?? Bundle(identifier: self.bundleIdentifier) else {
 			self.finish(with: LatestError.updateInfoUnavailable)
 			return
 		}
 		
 		DispatchQueue.main.async {
+			// A cancellation can win the race against this hop. Its teardown has already
+			// completed, so building an updater here would resurrect an operation nothing
+			// will tear down again, leaving Sparkle running against a dead operation.
+			guard !self.isTornDown else { return }
+
 			// Instantiate a new updater that performs the update
 			let updater = SPUUpdater(hostBundle: bundle, applicationBundle: bundle, userDriver: self, delegate: self)
-			
+
+			// Publish ownership before starting. `start()` can synchronously drive
+			// user-driver callbacks that finish the operation and reenter teardown; that
+			// teardown must be able to find and release this instance rather than leave it
+			// running unowned.
+			self.updater = updater
+
 			do {
 				try updater.start()
 			} catch let error {
 				self.finish(with: error)
+				return
 			}
-			
+
+			// Re-check: teardown may have run reentrantly from `start()`. Checking for
+			// updates now would start work on an operation that has already torn down.
+			// `updater` is deliberately not reassigned here — teardown may have cleared it
+			// on purpose.
+			guard !self.isTornDown else { return }
+
 			updater.checkForUpdates()
-			
-			self.updater = updater
 		}
 	}
 	
 	override func cancel() {
+		// cancel() can be invoked from any thread, but SPUUpdater and Sparkle's cancellation
+		// closure are main-thread-only. Do not touch either here: just flip the cancelled
+		// flag and finish. `finish()` owns the teardown and sees `isCancelled == true`, so
+		// it invokes and consumes the cancellation closure on the main thread, exactly once.
 		super.cancel()
-		
-		self.cancellationCallback?()
 		self.finish()
 	}
 	
 	override func finish() {
-		// Cleanup updater
-		self.updater = nil
-		
+		// Single owner of teardown for every finish path: user cancellation, success, error,
+		// and cancelled-before-start. On a user cancellation, invoke and consume Sparkle's
+		// cancellation closure; a normal success or error finish must not invoke it. Running
+		// before `super.finish()` guarantees teardown completes — and pending download
+		// progress is retired — before the terminal progress state is published.
+		self.performTeardownOnMain(invokeCancellation: self.isCancelled)
+
 		super.finish()
 	}
-	
-	
+
+	/// Whether teardown has begun. Main-confined.
+	///
+	/// `isFinished` cannot answer this: the teardown in `finish()` runs *before*
+	/// `StatefulOperation` transitions the operation to its finished state, so there is a
+	/// window in which teardown has completed while both `isFinished` and `isCancelled`
+	/// still read false. Sparkle callbacks and the queued initialization block land on the
+	/// main thread inside that window.
+	private var teardownStarted = false
+
+	/// Whether the operation has stopped accepting new Sparkle work. Main-confined.
+	private var isTornDown: Bool {
+		assert(Thread.isMainThread, "Must be called on main thread.")
+		return self.teardownStarted || self.isCancelled || self.isFinished
+	}
+
+	/// Releases the updater and, when `invokeCancellation` is true, invokes Sparkle's
+	/// cancellation closure — both synchronously on the main thread, because `SPUUpdater`
+	/// and the closure are main-thread-only. Synchronous execution is deadlock-free here:
+	/// nothing this operation schedules on the main queue ever blocks on the thread calling
+	/// `finish()` (observer notification in `UpdateQueue` is `DispatchQueue.main.async`).
+	/// The closure is read-and-cleared so it is invoked at most once across every finish
+	/// path, and a stored closure can no longer leak on a success or error finish.
+	private func performTeardownOnMain(invokeCancellation: Bool) {
+		let work = {
+			// Set first, before anything below can reenter: this is the only flag that
+			// reports "teardown already ran" inside the pre-`isFinished` window.
+			self.teardownStarted = true
+
+			// Retire pending and scheduled download progress before the terminal state is
+			// published, so no trailing `.downloading` can land after `.none`/`.error`.
+			self.invalidateProgressPublishing()
+
+			// Always consume the closure, even when it must not be invoked: leaving it
+			// stored on a success or error finish strands Sparkle's download cancellation.
+			// Reading and clearing before the call also keeps it at most once under
+			// reentrancy.
+			let callback = self.cancellationCallback
+			self.cancellationCallback = nil
+			if invokeCancellation {
+				callback?()
+			}
+
+			self.updater = nil
+		}
+
+		if Thread.isMainThread {
+			work()
+		} else {
+			DispatchQueue.main.sync(execute: work)
+		}
+	}
+
+
 	// MARK: - Downloading
 	
 	/// The estimated total length of the downloaded app bundle.
@@ -90,8 +157,36 @@ class SparkleUpdateOperation: UpdateOperation, @unchecked Sendable {
 
 	/// The length of already downloaded data.
 	fileprivate var receivedLength: UInt64 = 0
-	
-	
+
+	/// The minimum interval between two progress publications.
+	private static let progressPublicationInterval: DispatchTimeInterval = .seconds(1)
+
+	/// The most recent byte counts reported by Sparkle, awaiting publication.
+	private var pendingProgress: (loadedSize: Int64, totalSize: Int64)?
+
+	/// When the last progress state was published, if any.
+	private var lastProgressPublication: DispatchTime?
+
+	/// Whether a trailing publication has already been scheduled.
+	///
+	/// While true, further activity only refreshes `pendingProgress`; the scheduled work
+	/// publishes whatever the latest counts are when it runs.
+	private var hasScheduledProgressPublication = false
+
+	/// The publishing epoch a scheduled trailing publication belongs to.
+	///
+	/// A delayed block captures this value and drops out if it no longer matches, which is
+	/// what makes an already-queued block inert once a later phase has taken over the
+	/// progress state.
+	private var progressGeneration: UInt64 = 0
+
+	/// Whether download progress may still be published.
+	///
+	/// Cleared for good once extraction starts or teardown runs, so a stray late download
+	/// callback cannot reactivate publishing and overwrite a later phase.
+	private var isProgressPublishingActive = true
+
+
 	// MARK: - Installation
 	
 	/// Whether the app is open.
@@ -130,8 +225,8 @@ extension SparkleUpdateOperation: SPUUserDriver {
 		self.finish(with: error)
 		acknowledgement()
 	}
-	
-	func showUpdateInstalledAndRelaunched(_ relaunched: Bool, acknowledgement: @escaping () -> Void) {		
+
+	func showUpdateInstalledAndRelaunched(_ relaunched: Bool, acknowledgement: @escaping () -> Void) {
 		acknowledgement()
 		self.finish()
 	}
@@ -141,7 +236,14 @@ extension SparkleUpdateOperation: SPUUserDriver {
 	}
 
 	func showDownloadInitiated(cancellation: @escaping () -> Void) {
-		if self.isCancelled {
+		// Sparkle invokes user-driver callbacks on the main thread, so this and the closure
+		// it hands us are main-thread-safe. If teardown already ran — which `isTornDown`
+		// reports even inside the window where teardown completed but `isFinished` is still
+		// false — invoke the closure immediately and do not store it: nothing will consume a
+		// closure stored after teardown, so storing it would leave the download running
+		// forever. This direct call is then the single, at-most-once invocation. Otherwise
+		// store it for the finish path.
+		if self.isTornDown {
 			cancellation()
 			return
 		}
@@ -167,15 +269,83 @@ extension SparkleUpdateOperation: SPUUserDriver {
 		
 		self.scheduleProgressHandler()
 	}
-	
+
+	/// Coalesces download activity into at most one progress publication per second.
+	///
+	/// The whole coalescer is main-confined: Sparkle delivers user-driver callbacks on the
+	/// main thread and teardown synchronizes onto it, so phase changes and lifecycle
+	/// transitions are ordered against the coalescing state by the main queue alone — no
+	/// extra queue or lock, and no thread is ever blocked to pace publications.
+	///
+	/// Publishes immediately when the last publication is at least
+	/// `progressPublicationInterval` old, otherwise defers to the end of the current
+	/// interval. Activity arriving while a publication is already deferred only refreshes
+	/// the pending byte counts, so the deferred work always publishes the latest values —
+	/// and, because the last burst of a download still schedules one, a trailing update
+	/// always follows activity. No timer exists while the download is idle.
 	private func scheduleProgressHandler() {
-		self.progressScheduler.add(data: 1)
+		assert(Thread.isMainThread, "Must be called on main thread.")
+		guard self.isProgressPublishingActive else { return }
+
+		self.pendingProgress = (loadedSize: Int64(self.receivedLength), totalSize: Int64(self.expectedContentLength))
+
+		// A deferred publication is already pending and will pick up the counts just stored.
+		guard !self.hasScheduledProgressPublication else { return }
+
+		guard let last = self.lastProgressPublication,
+			  last + Self.progressPublicationInterval > .now() else {
+			self.publishPendingProgress()
+			return
+		}
+
+		let generation = self.progressGeneration
+		self.hasScheduledProgressPublication = true
+
+		DispatchQueue.main.asyncAfter(deadline: last + Self.progressPublicationInterval) { [weak self] in
+			guard let self = self else { return }
+
+			// Invalidated while this block was queued: a later phase owns the progress
+			// state now, and it already reset the scheduling flag. Do nothing at all.
+			guard self.progressGeneration == generation else { return }
+
+			self.hasScheduledProgressPublication = false
+			self.publishPendingProgress()
+		}
 	}
 
-	
+	/// Publishes the pending byte counts as the operation's progress state.
+	private func publishPendingProgress() {
+		assert(Thread.isMainThread, "Must be called on main thread.")
+		guard self.isProgressPublishingActive, let progress = self.pendingProgress else { return }
+
+		self.pendingProgress = nil
+		self.lastProgressPublication = .now()
+		self.progressState = .downloading(loadedSize: progress.loadedSize, totalSize: progress.totalSize)
+	}
+
+	/// Retires download progress publication, handing the progress state to a later phase.
+	///
+	/// Bumping the generation makes an already-scheduled trailing block inert, and clearing
+	/// the active flag stops a late download callback from starting a fresh one. Called
+	/// synchronously on the main thread before extraction publishes `.extracting` and inside
+	/// teardown before the terminal state is published, so once either has run no
+	/// `.downloading` can be published — or, because observers are notified via
+	/// `main.async`, be *delivered* — after the state that superseded it.
+	private func invalidateProgressPublishing() {
+		assert(Thread.isMainThread, "Must be called on main thread.")
+		self.progressGeneration &+= 1
+		self.pendingProgress = nil
+		self.hasScheduledProgressPublication = false
+		self.isProgressPublishingActive = false
+	}
+
+
 	// MARK: - Installing Update
 	
 	func showDownloadDidStartExtractingUpdate() {
+		// Downloading is over. Retire any trailing download publication first, otherwise it
+		// lands after this and leaves the UI showing download progress during extraction.
+		self.invalidateProgressPublishing()
 		self.progressState = .extracting(progress: 0)
 	}
 	


### PR DESCRIPTION
- Resolve the app bundle by its on-disk location (`Bundle(url:)`, falling back to `Bundle(path:)`, then `Bundle(identifier:)`). `Bundle(identifier:)` only resolves bundles already loaded into this process, so it could never find the app being updated.
- Replace the download-progress `DispatchSource` whose handler slept one second on a global queue with a main-confined coalescer: at most one publication per second, latest counts, a trailing update after the last burst, and no blocked worker thread or idle timer.
- Invalidate pending progress before extraction and before the terminal state, so a stale `.downloading` can no longer overwrite `.extracting`, `.none`, or `.error` and leave the UI stuck on a download progress bar.
- Make `finish()` the single teardown owner, synchronously on the main thread: `SPUUpdater` and Sparkle's cancellation closure are main-thread-only, but `cancel()` runs on any thread and used to invoke the closure directly (and `finish()` released the updater off-main). The closure is read-and-cleared, so it is invoked at most once and no longer leaks when a download finishes with an error.
- Guard the queued initialization block: don't build an updater after cancellation won the race, publish updater ownership before `start()`, return after a failed `start()` instead of falling through to `checkForUpdates()`, and re-check before `checkForUpdates()` so reentrant teardown from `start()` is honored.
- Handle the pre-`isFinished` teardown window in `showDownloadInitiated`: a cancellation closure arriving after teardown is invoked immediately, never stored, since a stored closure would leave the download running with no consumer.

Verification: the Latest app target builds cleanly (tested with the Xcode 27 beta toolchain). The `Latest Tests` target currently doesn't build on `develop` (unresolved `CommerceKit`/`StoreFoundation` module dependencies — happy to send that small search-path fix separately); with that fixed locally, the suite runs 25 tests with one failure (`VersionParserTest.testEmptyVersionParsing`) that reproduces on `develop` without this change, i.e. pre-existing and unrelated.

Fixes #601.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
